### PR TITLE
Add EPSG.io API key option and reprojection fallback

### DIFF
--- a/core/proj/reproj.py
+++ b/core/proj/reproj.py
@@ -19,6 +19,7 @@
 
 
 import math
+import logging
 
 from .srs import SRS
 from .utm import UTM, UTM_EPSG_CODES
@@ -30,324 +31,355 @@ from ..utils import BBOX
 from ..checkdeps import HAS_GDAL, HAS_PYPROJ
 from .. import settings
 
+log = logging.getLogger(__name__)
+
 if HAS_GDAL:
-	from osgeo import osr, gdal
+        from osgeo import osr, gdal
 
 if HAS_PYPROJ:
-	import pyproj
+        import pyproj
 
 
 ######################################
 # Build in functions
 
 def webMercToLonLat(x, y):
-	k = GRS80.perimeter/360
-	lon = x / k
-	lat = y / k
-	lat = 180 / math.pi * (2 * math.atan( math.exp( lat * math.pi / 180.0)) - math.pi / 2.0)
-	return lon, lat
+        k = GRS80.perimeter/360
+        lon = x / k
+        lat = y / k
+        lat = 180 / math.pi * (2 * math.atan( math.exp( lat * math.pi / 180.0)) - math.pi / 2.0)
+        return lon, lat
 
 def lonLatToWebMerc(lon, lat):
-	k = GRS80.perimeter/360
-	x = lon * k
-	lat = math.log( math.tan((90 + lat) * math.pi / 360.0 )) / (math.pi / 180.0)
-	y = lat * k
-	return x, y
+        k = GRS80.perimeter/360
+        x = lon * k
+        lat = math.log( math.tan((90 + lat) * math.pi / 360.0 )) / (math.pi / 180.0)
+        y = lat * k
+        return x, y
 
 
 ######################################
 # Raster reproj using GDAL
 
 def reprojImg(crs1, crs2, ds1, out_ul=None, out_size=None, out_res=None, sqPx=False, resamplAlg='BL', path=None, geoTiffOptions={'TFW':'YES', 'TILED':'YES', 'BIGTIFF':'YES', 'COMPRESS':'JPEG', 'JPEG_QUALITY':80, 'PHOTOMETRIC':'YCBCR'}):
-	'''
-	Use GDAL Python binding to reproject an image
-	crs1, crs2 >> epsg code
-	ds1 >> input GDAL dataset object
-	out_ul >> [tuple] output raster top left coords (same as input if None)
-	out_size >> |tuple], output raster size (same as input is None)
-	out_res >> [number], output raster resolution (same as input if None) (resx = resy)
-	sqPx >> [boolean] force square pixel resolution when resoltion is automatically computed
-	path >> a geotiff file path to store the result into (optional)
-	geoTiffOptions >> GDAL create option for tiff format (optional)
-	return ds2 >> output GDAL dataset object. If path is None, the dataset will be stored in memory however into a geotiff file on disk
-	'''
+        '''
+        Use GDAL Python binding to reproject an image
+        crs1, crs2 >> epsg code
+        ds1 >> input GDAL dataset object
+        out_ul >> [tuple] output raster top left coords (same as input if None)
+        out_size >> |tuple], output raster size (same as input is None)
+        out_res >> [number], output raster resolution (same as input if None) (resx = resy)
+        sqPx >> [boolean] force square pixel resolution when resoltion is automatically computed
+        path >> a geotiff file path to store the result into (optional)
+        geoTiffOptions >> GDAL create option for tiff format (optional)
+        return ds2 >> output GDAL dataset object. If path is None, the dataset will be stored in memory however into a geotiff file on disk
+        '''
 
-	if not HAS_GDAL:
-		raise NotImplementedError
+        if not HAS_GDAL:
+                raise NotImplementedError
 
-	geoTrans = ds1.GetGeoTransform()
-	if geoTrans is not None:
-		xmin, resx, rotx, ymax, roty, resy = geoTrans
-		#Note that instead of worldfile, topleft geotag is at corner not pixel center
-	else:
-		raise IOError("Reprojection fails: input raster is not georeferenced")
+        geoTrans = ds1.GetGeoTransform()
+        if geoTrans is not None:
+                xmin, resx, rotx, ymax, roty, resy = geoTrans
+                #Note that instead of worldfile, topleft geotag is at corner not pixel center
+        else:
+                raise IOError("Reprojection fails: input raster is not georeferenced")
 
 
-	img_w, img_h = ds1.RasterXSize, ds1.RasterYSize
-	nbBands = ds1.RasterCount
-	dtype = gdal.GetDataTypeName(ds1.GetRasterBand(1).DataType)
+        img_w, img_h = ds1.RasterXSize, ds1.RasterYSize
+        nbBands = ds1.RasterCount
+        dtype = gdal.GetDataTypeName(ds1.GetRasterBand(1).DataType)
 
-	if rotx == roty == 0:
-		xmax = xmin + img_w * resx
-		ymin = ymax + img_h * resy
-		bbox = BBOX(xmin, ymin, xmax, ymax)
-	else:
-		raise IOError("Raster must be rectified (no rotation parameters)")
-		#TODO reuse the GeoRef class to extract bbox even if there are rotation parameters
+        if rotx == roty == 0:
+                xmax = xmin + img_w * resx
+                ymin = ymax + img_h * resy
+                bbox = BBOX(xmin, ymin, xmax, ymax)
+        else:
+                raise IOError("Raster must be rectified (no rotation parameters)")
+                #TODO reuse the GeoRef class to extract bbox even if there are rotation parameters
 
-	#Assign input CRS to input datasource
-	prj1 = SRS(crs1).getOgrSpatialRef()
-	wkt1 = prj1.ExportToWkt()
-	ds1.SetProjection(wkt1)
+        #Assign input CRS to input datasource
+        prj1 = SRS(crs1).getOgrSpatialRef()
+        wkt1 = prj1.ExportToWkt()
+        ds1.SetProjection(wkt1)
 
-	#Build destination dataset
-	# ds2 will be a template empty raster to reproject the data into
-	# we can directly set its size, res and top left coord as expected
-	# reproject funtion will match the template (clip and resampling)
+        #Build destination dataset
+        # ds2 will be a template empty raster to reproject the data into
+        # we can directly set its size, res and top left coord as expected
+        # reproject funtion will match the template (clip and resampling)
 
-	if out_ul is not None:
-		xmin, ymax = out_ul
-	else:
-		xmin, ymax = reprojPt(crs1, crs2, xmin, ymax)
+        if out_ul is not None:
+                xmin, ymax = out_ul
+        else:
+                xmin, ymax = reprojPt(crs1, crs2, xmin, ymax)
 
-	#submit resolution and size
-	if out_res is not None and out_size is not None:
-		resx, resy = out_res, -out_res
-		img_w, img_h = out_size
+        #submit resolution and size
+        if out_res is not None and out_size is not None:
+                resx, resy = out_res, -out_res
+                img_w, img_h = out_size
 
-	#submit resolution and auto compute the best image size
-	if out_res is not None and out_size is None:
-		resx, resy = out_res, -out_res
-		#reprojected image size depend on final bbox and expected resolution
-		xmin, ymin, xmax, ymax = reprojBbox(crs1, crs2, bbox)
-		img_w = int( (xmax - xmin) / resx )
-		img_h = int( (ymax - ymin) / resy )
+        #submit resolution and auto compute the best image size
+        if out_res is not None and out_size is None:
+                resx, resy = out_res, -out_res
+                #reprojected image size depend on final bbox and expected resolution
+                xmin, ymin, xmax, ymax = reprojBbox(crs1, crs2, bbox)
+                img_w = int( (xmax - xmin) / resx )
+                img_h = int( (ymax - ymin) / resy )
 
-	#submit image size and ...
-	if out_res is None and out_size is not None:
-		img_w, img_h = out_size
-		#...let's res as source value ? (image will be croped)
+        #submit image size and ...
+        if out_res is None and out_size is not None:
+                img_w, img_h = out_size
+                #...let's res as source value ? (image will be croped)
 
-	#Keep original image px size and compute resolution to approximately preserve geosize
-	if out_res is None and out_size is None:
-		#find the res that match source diagolal size
-		xmin, ymin, xmax, ymax = reprojBbox(crs1, crs2, bbox)
-		'''
-		dst_diag = math.sqrt( (xmax - xmin)**2 + (ymax - ymin)**2)
-		px_diag = math.sqrt(img_w**2 + img_h**2)
-		res = dst_diag / px_diag
-		'''
-		resx = (xmax-xmin) / img_w
-		resy = -(ymax-ymin) / img_h
-		if sqPx:
-			resx = max(resx, abs(resy))
-			resy = -resx
+        #Keep original image px size and compute resolution to approximately preserve geosize
+        if out_res is None and out_size is None:
+                #find the res that match source diagolal size
+                xmin, ymin, xmax, ymax = reprojBbox(crs1, crs2, bbox)
+                '''
+                dst_diag = math.sqrt( (xmax - xmin)**2 + (ymax - ymin)**2)
+                px_diag = math.sqrt(img_w**2 + img_h**2)
+                res = dst_diag / px_diag
+                '''
+                resx = (xmax-xmin) / img_w
+                resy = -(ymax-ymin) / img_h
+                if sqPx:
+                        resx = max(resx, abs(resy))
+                        resy = -resx
 
-	if path is None:
-		ds2 = gdal.GetDriverByName('MEM').Create('', img_w, img_h, nbBands, gdal.GetDataTypeByName(dtype))
-	else:
-		gdal.SetConfigOption('GDAL_TIFF_INTERNAL_MASK', 'YES')
-		options = [str(k) + '=' + str(v) for k, v in geoTiffOptions.items()]
-		ds2 = gdal.GetDriverByName('GTiff').Create(path, img_w, img_h, nbBands, gdal.GetDataTypeByName(dtype), options)
-		if geoTiffOptions.get('COMPRESS', None) == 'JPEG':
-			ds2.CreateMaskBand(gdal.GMF_PER_DATASET)
-			ds2.GetRasterBand(1).GetMaskBand().Fill(255) #WARNING, it seems gdal.ReprojectImage does not honor internal mask !
-	geoTrans = (xmin, resx, 0, ymax, 0, resy)
-	ds2.SetGeoTransform(geoTrans)
-	prj2 = SRS(crs2).getOgrSpatialRef()
-	wkt2 = prj2.ExportToWkt()
-	ds2.SetProjection(wkt2)
+        if path is None:
+                ds2 = gdal.GetDriverByName('MEM').Create('', img_w, img_h, nbBands, gdal.GetDataTypeByName(dtype))
+        else:
+                gdal.SetConfigOption('GDAL_TIFF_INTERNAL_MASK', 'YES')
+                options = [str(k) + '=' + str(v) for k, v in geoTiffOptions.items()]
+                ds2 = gdal.GetDriverByName('GTiff').Create(path, img_w, img_h, nbBands, gdal.GetDataTypeByName(dtype), options)
+                if geoTiffOptions.get('COMPRESS', None) == 'JPEG':
+                        ds2.CreateMaskBand(gdal.GMF_PER_DATASET)
+                        ds2.GetRasterBand(1).GetMaskBand().Fill(255) #WARNING, it seems gdal.ReprojectImage does not honor internal mask !
+        geoTrans = (xmin, resx, 0, ymax, 0, resy)
+        ds2.SetGeoTransform(geoTrans)
+        prj2 = SRS(crs2).getOgrSpatialRef()
+        wkt2 = prj2.ExportToWkt()
+        ds2.SetProjection(wkt2)
 
-	#Perform the projection/resampling
-	# Resample algo
-	if resamplAlg == 'NN' : alg = gdal.GRA_NearestNeighbour
-	elif resamplAlg == 'BL' : alg = gdal.GRA_Bilinear
-	elif resamplAlg == 'CB' : alg = gdal.GRA_Cubic
-	elif resamplAlg == 'CBS' : alg = gdal.GRA_CubicSpline
-	elif resamplAlg == 'LCZ' : alg = gdal.GRA_Lanczos
-	# Memory limit (0 = no limit)
-	memLimit = 0
-	# Error in pixels (0 will use the exact transformer)
-	threshold = 0.25
-	# Warp options (http://www.gdal.org/structGDALWarpOptions.html)
-	opt = ['NUM_THREADS=ALL_CPUS, SAMPLE_GRID=YES']
-	#option parameters available since gdal 2.1
-	a, b, c = gdal.__version__.split('.', 2)
-	if (int(a) == 2 and int(b) >=1) or int(a) > 2:
-		gdal.ReprojectImage(ds1, ds2, wkt1, wkt2, alg, memLimit, threshold, options=opt)
-	else:
-		gdal.ReprojectImage(ds1, ds2, wkt1, wkt2, alg, memLimit, threshold)
+        #Perform the projection/resampling
+        # Resample algo
+        if resamplAlg == 'NN' : alg = gdal.GRA_NearestNeighbour
+        elif resamplAlg == 'BL' : alg = gdal.GRA_Bilinear
+        elif resamplAlg == 'CB' : alg = gdal.GRA_Cubic
+        elif resamplAlg == 'CBS' : alg = gdal.GRA_CubicSpline
+        elif resamplAlg == 'LCZ' : alg = gdal.GRA_Lanczos
+        # Memory limit (0 = no limit)
+        memLimit = 0
+        # Error in pixels (0 will use the exact transformer)
+        threshold = 0.25
+        # Warp options (http://www.gdal.org/structGDALWarpOptions.html)
+        opt = ['NUM_THREADS=ALL_CPUS, SAMPLE_GRID=YES']
+        #option parameters available since gdal 2.1
+        a, b, c = gdal.__version__.split('.', 2)
+        if (int(a) == 2 and int(b) >=1) or int(a) > 2:
+                gdal.ReprojectImage(ds1, ds2, wkt1, wkt2, alg, memLimit, threshold, options=opt)
+        else:
+                gdal.ReprojectImage(ds1, ds2, wkt1, wkt2, alg, memLimit, threshold)
 
-	#ds1 = None
+        #ds1 = None
 
-	return ds2
+        return ds2
 
 
 
 class Reproj():
 
-	def __init__(self, crs1, crs2):
+        def __init__(self, crs1, crs2):
 
-		#init CRS class
-		try:
-			crs1, crs2 = SRS(crs1), SRS(crs2)
-		except Exception as e:
-			raise ReprojError(str(e))
+                #init CRS class
+                try:
+                        crs1, crs2 = SRS(crs1), SRS(crs2)
+                except Exception as e:
+                        raise ReprojError(str(e))
 
-		if crs1 == crs2:
-			self.iproj = 'NO_REPROJ'
-			return
+                self._crs1 = crs1
+                self._crs2 = crs2
 
-		#Get proj engine from module settings
-		self.iproj = settings.proj_engine
-		if self.iproj not in ['AUTO', 'GDAL', 'PYPROJ', 'BUILTIN', 'EPSGIO']:
-			raise ReprojError('Wrong engine name')
+                if crs1 == crs2:
+                        self.iproj = 'NO_REPROJ'
+                        return
 
-		if self.iproj == 'AUTO':
-			# Init proj4 interface for this instance
-			if HAS_GDAL:
-				self.iproj = 'GDAL'
-			elif HAS_PYPROJ:
-				 self.iproj = 'PYPROJ'
-			elif ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)):
-				self.iproj = 'BUILTIN'
-			elif EPSGIO.ping():
-				#this is the slower solution, not suitable for reproject lot of points
-				self.iproj = 'EPSGIO'
-			else:
-				raise ReprojError('Too limited reprojection capabilities.')
-		else:
-			if (self.iproj == 'GDAL' and not HAS_GDAL) or (self.iproj == 'PYPROJ' and not HAS_PYPROJ):
-				raise ReprojError('Missing reproj engine')
-			if self.iproj == 'BUILTIN':
-				if not ( ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)) ):
-					raise ReprojError('Too limited built in reprojection capabilities')
-			if self.iproj == 'EPSGIO':
-				if not  EPSGIO.ping():
-					raise ReprojError('Cannot access epsg.io service')
+                #Get proj engine from module settings
+                self.iproj = settings.proj_engine
+                if self.iproj not in ['AUTO', 'GDAL', 'PYPROJ', 'BUILTIN', 'EPSGIO']:
+                        raise ReprojError('Wrong engine name')
 
-
-		if self.iproj == 'GDAL':
-			self.crs1 = crs1.getOgrSpatialRef()
-			self.crs2 = crs2.getOgrSpatialRef()
-			self.osrTransfo = osr.CoordinateTransformation(self.crs1, self.crs2)
-
-		elif self.iproj == 'PYPROJ':
-			self.crs1 = crs1.getPyProj()
-			self.crs2 = crs2.getPyProj()
-
-		elif self.iproj == 'EPSGIO':
-			if crs1.isEPSG and crs2.isEPSG:
-				self.crs1, self.crs2 = crs1.code, crs2.code
-			else:
-				raise ReprojError('EPSG.io support only EPSG code')
-
-		elif self.iproj == 'BUILTIN':
-			if ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)):
-				#just store codes
-				self.crs1, self.crs2 = crs1.code, crs2.code
-			else:
-				raise ReprojError('Not implemented transformation')
-			#init UTM class
-			if crs1.isUTM:
-				self.utm = UTM.init_from_epsg(crs1)
-			elif crs2.isUTM:
-				self.utm = UTM.init_from_epsg(crs2)
+                if self.iproj == 'AUTO':
+                        # Init proj4 interface for this instance
+                        if HAS_GDAL:
+                                self.iproj = 'GDAL'
+                        elif HAS_PYPROJ:
+                                self.iproj = 'PYPROJ'
+                        elif ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)):
+                                self.iproj = 'BUILTIN'
+                        elif EPSGIO.ping():
+                                #this is the slower solution, not suitable for reproject lot of points
+                                self.iproj = 'EPSGIO'
+                        else:
+                                raise ReprojError('Too limited reprojection capabilities.')
+                else:
+                        if (self.iproj == 'GDAL' and not HAS_GDAL) or (self.iproj == 'PYPROJ' and not HAS_PYPROJ):
+                                raise ReprojError('Missing reproj engine')
+                        if self.iproj == 'BUILTIN':
+                                if not ( ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)) ):
+                                        raise ReprojError('Too limited built in reprojection capabilities')
+                        if self.iproj == 'EPSGIO':
+                                if not  EPSGIO.ping():
+                                        raise ReprojError('Cannot access epsg.io service')
 
 
-	def pts(self, pts):
-		if len(pts) == 0:
-			return []
+                if self.iproj == 'GDAL':
+                        self.crs1 = self._crs1.getOgrSpatialRef()
+                        self.crs2 = self._crs2.getOgrSpatialRef()
+                        self.osrTransfo = osr.CoordinateTransformation(self.crs1, self.crs2)
 
-		if len(pts[0]) != 2:
-			raise ReprojError('Points must be [ (x,y) ]')
+                elif self.iproj == 'PYPROJ':
+                        self.crs1 = self._crs1.getPyProj()
+                        self.crs2 = self._crs2.getPyProj()
 
-		if self.iproj == 'NO_REPROJ':
-			return pts
+                elif self.iproj == 'EPSGIO':
+                        if crs1.isEPSG and crs2.isEPSG:
+                                self.crs1, self.crs2 = crs1.code, crs2.code
+                        else:
+                                raise ReprojError('EPSG.io support only EPSG code')
 
-		if self.iproj == 'GDAL':
-			#Since PROJ 6, the order of coordinates for geographic crs is latitude first, longitude second.
-			if hasattr(osr, 'GetPROJVersionMajor'):
-				projVersion = osr.GetPROJVersionMajor()
-			else:
-				projVersion = 4
-			if projVersion >= 6 and self.crs1.IsGeographic():
-				pts = [ (pt[1], pt[0]) for pt in pts]
-			if self.crs2.IsGeographic():
-				ys, xs, _zs = zip(*self.osrTransfo.TransformPoints(pts))
-			else:
-				xs, ys, _zs = zip(*self.osrTransfo.TransformPoints(pts))
-			return list(zip(xs, ys))
-
-		elif self.iproj == 'PYPROJ':
-			if self.crs1.crs.is_geographic:
-				ys, xs = zip(*pts)
-			else:
-				xs, ys = zip(*pts)
-			transformer = pyproj.Transformer.from_proj(self.crs1, self.crs2)
-			if self.crs2.crs.is_geographic:
-				ys, xs = transformer.transform(xs, ys)
-			else:
-				xs, ys = transformer.transform(xs, ys)
-			return list(zip(xs, ys))
-
-		elif self.iproj == 'EPSGIO':
-			return EPSGIO.reprojPts(self.crs1, self.crs2, pts)
-
-		elif self.iproj == 'BUILTIN':
-			#Web Mercator
-			if self.crs1 == 4326 and self.crs2 == 3857:
-				return [lonLatToWebMerc(*pt) for pt in pts]
-			elif self.crs1 == 3857 and self.crs2 == 4326:
-				return [webMercToLonLat(*pt) for pt in pts]
-			#UTM
-			if self.crs1 == 4326 and self.crs2 in UTM_EPSG_CODES:
-				return [self.utm.lonlat_to_utm(*pt) for pt in pts]
-			elif self.crs1 in UTM_EPSG_CODES and self.crs2 == 4326:
-				return [self.utm.utm_to_lonlat(*pt) for pt in pts]
-
-	def pt(self, x, y):
-		if x is None or y is None:
-			raise ReprojError('Cannot reproj None coordinates')
-		return self.pts([(x,y)])[0]
+                elif self.iproj == 'BUILTIN':
+                        if ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)):
+                                #just store codes
+                                self.crs1, self.crs2 = crs1.code, crs2.code
+                        else:
+                                raise ReprojError('Not implemented transformation')
+                        #init UTM class
+                        if crs1.isUTM:
+                                self.utm = UTM.init_from_epsg(crs1)
+                        elif crs2.isUTM:
+                                self.utm = UTM.init_from_epsg(crs2)
 
 
-	def bbox(self, bbox):
-		'''io type = BBOX() class'''
-		if not isinstance(bbox, BBOX):
-			bbox = BBOX(*bbox) #list must be ordered from bottom left upper right
-		corners = self.pts(bbox.corners)
-		_xmin = min( pt[0] for pt in corners )
-		_xmax = max( pt[0] for pt in corners )
-		_ymin = min( pt[1] for pt in corners )
-		_ymax = max( pt[1] for pt in corners )
-		if bbox.hasZ:
-			return BBOX(_xmin, _ymin, bbox.zmin, _xmax, _ymax, bbox.zmax)
-		else:
-			return BBOX(_xmin, _ymin, _xmax, _ymax)
+        def _fallback(self):
+                if HAS_GDAL:
+                        self.crs1 = self._crs1.getOgrSpatialRef()
+                        self.crs2 = self._crs2.getOgrSpatialRef()
+                        self.osrTransfo = osr.CoordinateTransformation(self.crs1, self.crs2)
+                        self.iproj = 'GDAL'
+                        return True
+                elif HAS_PYPROJ:
+                        self.crs1 = self._crs1.getPyProj()
+                        self.crs2 = self._crs2.getPyProj()
+                        self.iproj = 'PYPROJ'
+                        return True
+                return False
+
+
+        def pts(self, pts):
+                if len(pts) == 0:
+                        return []
+
+                if len(pts[0]) != 2:
+                        raise ReprojError('Points must be [ (x,y) ]')
+
+                if self.iproj == 'NO_REPROJ':
+                        return pts
+
+                if self.iproj == 'GDAL':
+                        #Since PROJ 6, the order of coordinates for geographic crs is latitude first, longitude second.
+                        if hasattr(osr, 'GetPROJVersionMajor'):
+                                projVersion = osr.GetPROJVersionMajor()
+                        else:
+                                projVersion = 4
+                        if projVersion >= 6 and self.crs1.IsGeographic():
+                                pts = [ (pt[1], pt[0]) for pt in pts]
+                        if self.crs2.IsGeographic():
+                                ys, xs, _zs = zip(*self.osrTransfo.TransformPoints(pts))
+                        else:
+                                xs, ys, _zs = zip(*self.osrTransfo.TransformPoints(pts))
+                        return list(zip(xs, ys))
+
+                elif self.iproj == 'PYPROJ':
+                        if self.crs1.crs.is_geographic:
+                                ys, xs = zip(*pts)
+                        else:
+                                xs, ys = zip(*pts)
+                        transformer = pyproj.Transformer.from_proj(self.crs1, self.crs2)
+                        if self.crs2.crs.is_geographic:
+                                ys, xs = transformer.transform(xs, ys)
+                        else:
+                                xs, ys = transformer.transform(xs, ys)
+                        return list(zip(xs, ys))
+
+                elif self.iproj == 'EPSGIO':
+                        if len(pts) > EPSGIO.MAX_POINTS and self._fallback():
+                                log.warning('Switching from epsg.io to local engine due to feature limit')
+                                return self.pts(pts)
+                        try:
+                                return EPSGIO.reprojPts(self.crs1, self.crs2, pts)
+                        except Exception as e:
+                                log.warning('epsg.io reprojection failed: %s', e)
+                                if self._fallback():
+                                        return self.pts(pts)
+                                if isinstance(e, ReprojError):
+                                        raise
+                                raise ReprojError(str(e))
+
+                elif self.iproj == 'BUILTIN':
+                        #Web Mercator
+                        if self.crs1 == 4326 and self.crs2 == 3857:
+                                return [lonLatToWebMerc(*pt) for pt in pts]
+                        elif self.crs1 == 3857 and self.crs2 == 4326:
+                                return [webMercToLonLat(*pt) for pt in pts]
+                        #UTM
+                        if self.crs1 == 4326 and self.crs2 in UTM_EPSG_CODES:
+                                return [self.utm.lonlat_to_utm(*pt) for pt in pts]
+                        elif self.crs1 in UTM_EPSG_CODES and self.crs2 == 4326:
+                                return [self.utm.utm_to_lonlat(*pt) for pt in pts]
+
+        def pt(self, x, y):
+                if x is None or y is None:
+                        raise ReprojError('Cannot reproj None coordinates')
+                return self.pts([(x,y)])[0]
+
+
+        def bbox(self, bbox):
+                '''io type = BBOX() class'''
+                if not isinstance(bbox, BBOX):
+                        bbox = BBOX(*bbox) #list must be ordered from bottom left upper right
+                corners = self.pts(bbox.corners)
+                _xmin = min( pt[0] for pt in corners )
+                _xmax = max( pt[0] for pt in corners )
+                _ymin = min( pt[1] for pt in corners )
+                _ymax = max( pt[1] for pt in corners )
+                if bbox.hasZ:
+                        return BBOX(_xmin, _ymin, bbox.zmin, _xmax, _ymax, bbox.zmax)
+                else:
+                        return BBOX(_xmin, _ymin, _xmax, _ymax)
 
 
 
 def reprojPt(crs1, crs2, x, y):
-	"""
-	Reproject x1,y1 coords from crs1 to crs2
-	crs can be an EPSG code (interger or string) or a proj4 string
-	WARN : do not use this function in a loop because Reproj() init is slow
-	"""
-	rprj = Reproj(crs1, crs2)
-	return rprj.pt(x, y)
+        """
+        Reproject x1,y1 coords from crs1 to crs2
+        crs can be an EPSG code (interger or string) or a proj4 string
+        WARN : do not use this function in a loop because Reproj() init is slow
+        """
+        rprj = Reproj(crs1, crs2)
+        return rprj.pt(x, y)
 
 
 def reprojPts(crs1, crs2, pts):
-	"""
-	Reproject [pts] from crs1 to crs2
-	crs can be an EPSG code (integer or srid string) or a proj4 string
-	pts must be [(x,y)]
-	WARN : do not use this function in a loop because Reproj() init is slow
-	"""
-	rprj = Reproj(crs1, crs2)
-	return rprj.pts(pts)
+        """
+        Reproject [pts] from crs1 to crs2
+        crs can be an EPSG code (integer or srid string) or a proj4 string
+        pts must be [(x,y)]
+        WARN : do not use this function in a loop because Reproj() init is slow
+        """
+        rprj = Reproj(crs1, crs2)
+        return rprj.pts(pts)
 
 def reprojBbox(crs1, crs2, bbox):
-	rprj = Reproj(crs1, crs2)
-	return rprj.bbox(bbox)
+        rprj = Reproj(crs1, crs2)
+        return rprj.bbox(bbox)

--- a/core/settings.json
+++ b/core/settings.json
@@ -1,5 +1,6 @@
 {
 	"proj_engine": "AUTO",
-	"img_engine": "AUTO",
-	"user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
+        "img_engine": "AUTO",
+        "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0",
+        "epsgio_key": ""
 }

--- a/core/settings.py
+++ b/core/settings.py
@@ -5,59 +5,61 @@ import json
 from .checkdeps import HAS_GDAL, HAS_PYPROJ, HAS_IMGIO, HAS_PIL
 
 def getAvailableProjEngines():
-	engines = ['AUTO', 'BUILTIN']
-	#if EPSGIO.ping():
-	engines.append('EPSGIO')
-	if HAS_GDAL:
-		engines.append('GDAL')
-	if HAS_PYPROJ:
-		engines.append('PYPROJ')
-	return engines
+        engines = ['AUTO', 'BUILTIN']
+        #if EPSGIO.ping():
+        engines.append('EPSGIO')
+        if HAS_GDAL:
+                engines.append('GDAL')
+        if HAS_PYPROJ:
+                engines.append('PYPROJ')
+        return engines
 
 def getAvailableImgEngines():
-	engines = ['AUTO']
-	if HAS_GDAL:
-		engines.append('GDAL')
-	if HAS_IMGIO:
-		engines.append('IMGIO')
-	if HAS_PIL:
-		engines.append('PIL')
-	return engines
+        engines = ['AUTO']
+        if HAS_GDAL:
+                engines.append('GDAL')
+        if HAS_IMGIO:
+                engines.append('IMGIO')
+        if HAS_PIL:
+                engines.append('PIL')
+        return engines
 
 
 class Settings():
 
-	def __init__(self, **kwargs):
-		self._proj_engine = kwargs['proj_engine']
-		self._img_engine = kwargs['img_engine']
-		self.user_agent = kwargs['user_agent']
+        def __init__(self, **kwargs):
+                self._proj_engine = kwargs['proj_engine']
+                self._img_engine = kwargs['img_engine']
+                self.user_agent = kwargs['user_agent']
+                # Optional API key for epsg.io reprojection service
+                self.epsgio_key = kwargs.get('epsgio_key', '')
 
-	@property
-	def proj_engine(self):
-		return self._proj_engine
+        @property
+        def proj_engine(self):
+                return self._proj_engine
 
-	@proj_engine.setter
-	def proj_engine(self, engine):
-		if engine not in getAvailableProjEngines():
-			raise IOError
-		else:
-			self._proj_engine = engine
+        @proj_engine.setter
+        def proj_engine(self, engine):
+                if engine not in getAvailableProjEngines():
+                        raise IOError
+                else:
+                        self._proj_engine = engine
 
-	@property
-	def img_engine(self):
-		return self._img_engine
+        @property
+        def img_engine(self):
+                return self._img_engine
 
-	@img_engine.setter
-	def img_engine(self, engine):
-		if engine not in getAvailableImgEngines():
-			raise IOError
-		else:
-			self._img_engine = engine
+        @img_engine.setter
+        def img_engine(self, engine):
+                if engine not in getAvailableImgEngines():
+                        raise IOError
+                else:
+                        self._img_engine = engine
 
 
 cfgFile = os.path.join(os.path.dirname(__file__), "settings.json")
 
 with open(cfgFile, 'r') as cfg:
-		prefs = json.load(cfg)
+                prefs = json.load(cfg)
 
 settings = Settings(**prefs)

--- a/operators/io_import_shp.py
+++ b/operators/io_import_shp.py
@@ -15,7 +15,7 @@ from ..core.lib.shapefile import Reader as shpReader
 from ..geoscene import GeoScene, georefManagerLayout
 from ..prefs import PredefCRS
 from ..core import BBOX
-from ..core.proj import Reproj
+from ..core.proj import Reproj, EPSGIO
 from ..core.utils import perf_clock
 
 from .utils import adjust3Dview, getBBOX, DropToGround
@@ -42,717 +42,715 @@ featureType={
 
 """
 dbf fields type:
-	C is ASCII characters
-	N is a double precision integer limited to around 18 characters in length
-	D is for dates in the YYYYMMDD format, with no spaces or hyphens between the sections
-	F is for floating point numbers with the same length limits as N
-	L is for logical data which is stored in the shapefile's attribute table as a short integer as a 1 (true) or a 0 (false).
-	The values it can receive are 1, 0, y, n, Y, N, T, F or the python builtins True and False
+        C is ASCII characters
+        N is a double precision integer limited to around 18 characters in length
+        D is for dates in the YYYYMMDD format, with no spaces or hyphens between the sections
+        F is for floating point numbers with the same length limits as N
+        L is for logical data which is stored in the shapefile's attribute table as a short integer as a 1 (true) or a 0 (false).
+        The values it can receive are 1, 0, y, n, Y, N, T, F or the python builtins True and False
 """
 
 
 class IMPORTGIS_OT_shapefile_file_dialog(Operator):
-	"""Select shp file, loads the fields and start importgis.shapefile_props_dialog operator"""
+        """Select shp file, loads the fields and start importgis.shapefile_props_dialog operator"""
 
-	bl_idname = "importgis.shapefile_file_dialog"
-	bl_description = 'Import ESRI shapefile (.shp)'
-	bl_label = "Import SHP"
-	bl_options = {'INTERNAL'}
+        bl_idname = "importgis.shapefile_file_dialog"
+        bl_description = 'Import ESRI shapefile (.shp)'
+        bl_label = "Import SHP"
+        bl_options = {'INTERNAL'}
 
-	# Import dialog properties
-	filepath: StringProperty(
-		name="File Path",
-		description="Filepath used for importing the file",
-		maxlen=1024,
-		subtype='FILE_PATH' )
+        # Import dialog properties
+        filepath: StringProperty(
+                name="File Path",
+                description="Filepath used for importing the file",
+                maxlen=1024,
+                subtype='FILE_PATH' )
 
-	filename_ext = ".shp"
+        filename_ext = ".shp"
 
-	filter_glob: StringProperty(
-			default = "*.shp",
-			options = {'HIDDEN'} )
+        filter_glob: StringProperty(
+                        default = "*.shp",
+                        options = {'HIDDEN'} )
 
-	def invoke(self, context, event):
-		context.window_manager.fileselect_add(self)
-		return {'RUNNING_MODAL'}
+        def invoke(self, context, event):
+                context.window_manager.fileselect_add(self)
+                return {'RUNNING_MODAL'}
 
-	def draw(self, context):
-		layout = self.layout
-		layout.label(text="Options will be available")
-		layout.label(text="after selecting a file")
+        def draw(self, context):
+                layout = self.layout
+                layout.label(text="Options will be available")
+                layout.label(text="after selecting a file")
 
-	def execute(self, context):
-		if os.path.exists(self.filepath):
-			bpy.ops.importgis.shapefile_props_dialog('INVOKE_DEFAULT', filepath=self.filepath)
-		else:
-			self.report({'ERROR'}, "Invalid filepath")
-		return{'FINISHED'}
+        def execute(self, context):
+                if os.path.exists(self.filepath):
+                        bpy.ops.importgis.shapefile_props_dialog('INVOKE_DEFAULT', filepath=self.filepath)
+                else:
+                        self.report({'ERROR'}, "Invalid filepath")
+                return{'FINISHED'}
 
 
 
 class IMPORTGIS_OT_shapefile_props_dialog(Operator):
-	"""Shapefile importer properties dialog"""
+        """Shapefile importer properties dialog"""
 
-	bl_idname = "importgis.shapefile_props_dialog"
-	bl_description = 'Import ESRI shapefile (.shp)'
-	bl_label = "Import SHP"
-	bl_options = {"INTERNAL"}
+        bl_idname = "importgis.shapefile_props_dialog"
+        bl_description = 'Import ESRI shapefile (.shp)'
+        bl_label = "Import SHP"
+        bl_options = {"INTERNAL"}
 
-	filepath: StringProperty()
+        filepath: StringProperty()
 
-	#special function to auto redraw an operator popup called through invoke_props_dialog
-	def check(self, context):
-		return True
+        #special function to auto redraw an operator popup called through invoke_props_dialog
+        def check(self, context):
+                return True
 
-	def listFields(self, context):
-		fieldsItems = []
-		try:
-			shp = shpReader(self.filepath)
-		except Exception as e:
-			log.warning("Unable to read shapefile fields", exc_info=True)
-			return fieldsItems
-		fields = [field for field in shp.fields if field[0] != 'DeletionFlag'] #ignore default DeletionFlag field
-		for i, field in enumerate(fields):
-			#put each item in a tuple (key, label, tooltip)
-			fieldsItems.append( (field[0], field[0], '') )
-		return fieldsItems
+        def listFields(self, context):
+                fieldsItems = []
+                try:
+                        shp = shpReader(self.filepath)
+                except Exception as e:
+                        log.warning("Unable to read shapefile fields", exc_info=True)
+                        return fieldsItems
+                fields = [field for field in shp.fields if field[0] != 'DeletionFlag'] #ignore default DeletionFlag field
+                for i, field in enumerate(fields):
+                        #put each item in a tuple (key, label, tooltip)
+                        fieldsItems.append( (field[0], field[0], '') )
+                return fieldsItems
 
-	# Shapefile CRS definition
-	def listPredefCRS(self, context):
-		return PredefCRS.getEnumItems()
+        # Shapefile CRS definition
+        def listPredefCRS(self, context):
+                return PredefCRS.getEnumItems()
 
-	def listObjects(self, context):
-		objs = []
-		for index, object in enumerate(bpy.context.scene.objects):
-			if object.type == 'MESH':
-				#put each object in a tuple (key, label, tooltip) and add this to the objects list
-				objs.append((object.name, object.name, "Object named " + object.name))
-		return objs
+        def listObjects(self, context):
+                objs = []
+                for index, object in enumerate(bpy.context.scene.objects):
+                        if object.type == 'MESH':
+                                #put each object in a tuple (key, label, tooltip) and add this to the objects list
+                                objs.append((object.name, object.name, "Object named " + object.name))
+                return objs
 
-	reprojection: BoolProperty(
-			name="Specifiy shapefile CRS",
-			description="Specifiy shapefile CRS if it's different from scene CRS",
-			default=False )
+        reprojection: BoolProperty(
+                        name="Specifiy shapefile CRS",
+                        description="Specifiy shapefile CRS if it's different from scene CRS",
+                        default=False )
 
-	shpCRS: EnumProperty(
-		name = "Shapefile CRS",
-		description = "Choose a Coordinate Reference System",
-		items = listPredefCRS)
+        shpCRS: EnumProperty(
+                name = "Shapefile CRS",
+                description = "Choose a Coordinate Reference System",
+                items = listPredefCRS)
 
-	# Elevation source
-	vertsElevSource: EnumProperty(
-			name="Elevation source",
-			description="Select the source of vertices z value",
-			items=[
-			('NONE', 'None', "Flat geometry"),
-			('GEOM', 'Geometry', "Use z value from shape geometry if exists"),
-			('FIELD', 'Field', "Extract z elevation value from an attribute field"),
-			('OBJ', 'Object', "Get z elevation value from an existing ground mesh")
-			],
-			default='GEOM')
+        # Elevation source
+        vertsElevSource: EnumProperty(
+                        name="Elevation source",
+                        description="Select the source of vertices z value",
+                        items=[
+                        ('NONE', 'None', "Flat geometry"),
+                        ('GEOM', 'Geometry', "Use z value from shape geometry if exists"),
+                        ('FIELD', 'Field', "Extract z elevation value from an attribute field"),
+                        ('OBJ', 'Object', "Get z elevation value from an existing ground mesh")
+                        ],
+                        default='GEOM')
 
-	# Elevation object
-	objElevLst: EnumProperty(
-		name="Elev. object",
-		description="Choose the mesh from which extract z elevation",
-		items=listObjects )
+        # Elevation object
+        objElevLst: EnumProperty(
+                name="Elev. object",
+                description="Choose the mesh from which extract z elevation",
+                items=listObjects )
 
-	# Elevation field
-	'''
-	useFieldElev: BoolProperty(
-			name="Elevation from field",
-			description="Extract z elevation value from an attribute field",
-			default=False )
-	'''
-	fieldElevName: EnumProperty(
-		name = "Elev. field",
-		description = "Choose field",
-		items = listFields )
+        # Elevation field
+        '''
+        useFieldElev: BoolProperty(
+                        name="Elevation from field",
+                        description="Extract z elevation value from an attribute field",
+                        default=False )
+        '''
+        fieldElevName: EnumProperty(
+                name = "Elev. field",
+                description = "Choose field",
+                items = listFields )
 
-	#Extrusion field
-	useFieldExtrude: BoolProperty(
-			name="Extrusion from field",
-			description="Extract z extrusion value from an attribute field",
-			default=False )
+        #Extrusion field
+        useFieldExtrude: BoolProperty(
+                        name="Extrusion from field",
+                        description="Extract z extrusion value from an attribute field",
+                        default=False )
 
-	fieldExtrudeName: EnumProperty(
-		name = "Field",
-		description = "Choose field",
-		items = listFields )
+        fieldExtrudeName: EnumProperty(
+                name = "Field",
+                description = "Choose field",
+                items = listFields )
 
-	#Extrusion axis
-	extrusionAxis: EnumProperty(
-			name="Extrude along",
-			description="Select extrusion axis",
-			items=[ ('Z', 'z axis', "Extrude along Z axis"),
-			('NORMAL', 'Normal', "Extrude along normal")] )
+        #Extrusion axis
+        extrusionAxis: EnumProperty(
+                        name="Extrude along",
+                        description="Select extrusion axis",
+                        items=[ ('Z', 'z axis', "Extrude along Z axis"),
+                        ('NORMAL', 'Normal', "Extrude along normal")] )
 
-	#Create separate objects
-	separateObjects: BoolProperty(
-			name="Separate objects",
-			description="Warning : can be very slow with lot of features",
-			default=False )
+        #Create separate objects
+        separateObjects: BoolProperty(
+                        name="Separate objects",
+                        description="Warning : can be very slow with lot of features",
+                        default=False )
 
-	#Name objects from field
-	useFieldName: BoolProperty(
-			name="Object name from field",
-			description="Extract name for created objects from an attribute field",
-			default=False )
-	fieldObjName: EnumProperty(
-		name = "Field",
-		description = "Choose field",
-		items = listFields )
-
-
-	def draw(self, context):
-		#Function used by blender to draw the panel.
-		scn = context.scene
-		layout = self.layout
-
-		#
-		layout.prop(self, 'vertsElevSource')
-		#
-		#layout.prop(self, 'useFieldElev')
-		if self.vertsElevSource == 'FIELD':
-			layout.prop(self, 'fieldElevName')
-		elif self.vertsElevSource == 'OBJ':
-			layout.prop(self, 'objElevLst')
-		#
-		layout.prop(self, 'useFieldExtrude')
-		if self.useFieldExtrude:
-			layout.prop(self, 'fieldExtrudeName')
-			layout.prop(self, 'extrusionAxis')
-		#
-		layout.prop(self, 'separateObjects')
-		if self.separateObjects:
-			layout.prop(self, 'useFieldName')
-		else:
-			self.useFieldName = False
-		if self.separateObjects and self.useFieldName:
-			layout.prop(self, 'fieldObjName')
-		#
-		geoscn = GeoScene()
-		#geoscnPrefs = context.preferences.addons['geoscene'].preferences
-		if geoscn.isPartiallyGeoref:
-			layout.prop(self, 'reprojection')
-			if self.reprojection:
-				self.shpCRSInputLayout(context)
-			#
-			georefManagerLayout(self, context)
-		else:
-			self.shpCRSInputLayout(context)
+        #Name objects from field
+        useFieldName: BoolProperty(
+                        name="Object name from field",
+                        description="Extract name for created objects from an attribute field",
+                        default=False )
+        fieldObjName: EnumProperty(
+                name = "Field",
+                description = "Choose field",
+                items = listFields )
 
 
-	def shpCRSInputLayout(self, context):
-		layout = self.layout
-		row = layout.row(align=True)
-		#row.prop(self, "shpCRS", text='CRS')
-		split = row.split(factor=0.35, align=True)
-		split.label(text='CRS:')
-		split.prop(self, "shpCRS", text='')
-		row.operator("bgis.add_predef_crs", text='', icon='ADD')
+        def draw(self, context):
+                #Function used by blender to draw the panel.
+                scn = context.scene
+                layout = self.layout
+
+                #
+                layout.prop(self, 'vertsElevSource')
+                #
+                #layout.prop(self, 'useFieldElev')
+                if self.vertsElevSource == 'FIELD':
+                        layout.prop(self, 'fieldElevName')
+                elif self.vertsElevSource == 'OBJ':
+                        layout.prop(self, 'objElevLst')
+                #
+                layout.prop(self, 'useFieldExtrude')
+                if self.useFieldExtrude:
+                        layout.prop(self, 'fieldExtrudeName')
+                        layout.prop(self, 'extrusionAxis')
+                #
+                layout.prop(self, 'separateObjects')
+                if self.separateObjects:
+                        layout.prop(self, 'useFieldName')
+                else:
+                        self.useFieldName = False
+                if self.separateObjects and self.useFieldName:
+                        layout.prop(self, 'fieldObjName')
+                #
+                geoscn = GeoScene()
+                #geoscnPrefs = context.preferences.addons['geoscene'].preferences
+                if geoscn.isPartiallyGeoref:
+                        layout.prop(self, 'reprojection')
+                        if self.reprojection:
+                                self.shpCRSInputLayout(context)
+                        #
+                        georefManagerLayout(self, context)
+                else:
+                        self.shpCRSInputLayout(context)
 
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)
+        def shpCRSInputLayout(self, context):
+                layout = self.layout
+                row = layout.row(align=True)
+                #row.prop(self, "shpCRS", text='CRS')
+                split = row.split(factor=0.35, align=True)
+                split.label(text='CRS:')
+                split.prop(self, "shpCRS", text='')
+                row.operator("bgis.add_predef_crs", text='', icon='ADD')
 
-	def execute(self, context):
 
-		#elevField = self.fieldElevName if self.useFieldElev else ""
-		elevField = self.fieldElevName if self.vertsElevSource == 'FIELD' else ""
-		extrudField = self.fieldExtrudeName if self.useFieldExtrude else ""
-		nameField = self.fieldObjName if self.useFieldName else ""
-		if self.vertsElevSource == 'OBJ':
-			if not self.objElevLst:
-				self.report({'ERROR'}, "No elevation object")
-				return {'CANCELLED'}
-			else:
-				objElevName = self.objElevLst
-		else:
-			objElevName = '' #will not be used
+        def invoke(self, context, event):
+                return context.window_manager.invoke_props_dialog(self)
 
-		geoscn = GeoScene()
-		if geoscn.isBroken:
-			self.report({'ERROR'}, "Scene georef is broken, please fix it beforehand")
-			return {'CANCELLED'}
+        def execute(self, context):
 
-		if geoscn.isGeoref:
-			if self.reprojection:
-				shpCRS = self.shpCRS
-			else:
-				shpCRS = geoscn.crs
-		else:
-			shpCRS = self.shpCRS
+                #elevField = self.fieldElevName if self.useFieldElev else ""
+                elevField = self.fieldElevName if self.vertsElevSource == 'FIELD' else ""
+                extrudField = self.fieldExtrudeName if self.useFieldExtrude else ""
+                nameField = self.fieldObjName if self.useFieldName else ""
+                if self.vertsElevSource == 'OBJ':
+                        if not self.objElevLst:
+                                self.report({'ERROR'}, "No elevation object")
+                                return {'CANCELLED'}
+                        else:
+                                objElevName = self.objElevLst
+                else:
+                        objElevName = '' #will not be used
 
-		try:
-			bpy.ops.importgis.shapefile('INVOKE_DEFAULT', filepath=self.filepath, shpCRS=shpCRS, elevSource=self.vertsElevSource,
-				fieldElevName=elevField, objElevName=objElevName, fieldExtrudeName=extrudField, fieldObjName=nameField,
-				extrusionAxis=self.extrusionAxis, separateObjects=self.separateObjects)
-		except Exception as e:
-			log.error('Shapefile import fails', exc_info=True)
-			self.report({'ERROR'}, 'Shapefile import fails, check logs.')
-			return {'CANCELLED'}
+                geoscn = GeoScene()
+                if geoscn.isBroken:
+                        self.report({'ERROR'}, "Scene georef is broken, please fix it beforehand")
+                        return {'CANCELLED'}
 
-		return{'FINISHED'}
+                if geoscn.isGeoref:
+                        if self.reprojection:
+                                shpCRS = self.shpCRS
+                        else:
+                                shpCRS = geoscn.crs
+                else:
+                        shpCRS = self.shpCRS
+
+                try:
+                        bpy.ops.importgis.shapefile('INVOKE_DEFAULT', filepath=self.filepath, shpCRS=shpCRS, elevSource=self.vertsElevSource,
+                                fieldElevName=elevField, objElevName=objElevName, fieldExtrudeName=extrudField, fieldObjName=nameField,
+                                extrusionAxis=self.extrusionAxis, separateObjects=self.separateObjects)
+                except Exception as e:
+                        log.error('Shapefile import fails', exc_info=True)
+                        self.report({'ERROR'}, 'Shapefile import fails, check logs.')
+                        return {'CANCELLED'}
+
+                return{'FINISHED'}
 
 
 class IMPORTGIS_OT_shapefile(Operator):
-	"""Import from ESRI shapefile file format (.shp)"""
-
-	bl_idname = "importgis.shapefile" # important since its how bpy.ops.import.shapefile is constructed (allows calling operator from python console or another script)
-	#bl_idname rules: must contain one '.' (dot) charactere, no capital letters, no reserved words (like 'import')
-	bl_description = 'Import ESRI shapefile (.shp)'
-	bl_label = "Import SHP"
-	bl_options = {"UNDO"}
-
-	filepath: StringProperty()
-
-	shpCRS: StringProperty(name = "Shapefile CRS", description = "Coordinate Reference System")
-
-	elevSource: StringProperty(name = "Elevation source", description = "Elevation source", default='GEOM') # [NONE, GEOM, OBJ, FIELD]
-	objElevName: StringProperty(name = "Elevation object name", description = "")
-
-	fieldElevName: StringProperty(name = "Elevation field", description = "Field name")
-	fieldExtrudeName: StringProperty(name = "Extrusion field", description = "Field name")
-	fieldObjName: StringProperty(name = "Objects names field", description = "Field name")
-
-	#Extrusion axis
-	extrusionAxis: EnumProperty(
-			name="Extrude along",
-			description="Select extrusion axis",
-			items=[ ('Z', 'z axis', "Extrude along Z axis"),
-			('NORMAL', 'Normal', "Extrude along normal")]
-			)
-	#Create separate objects
-	separateObjects: BoolProperty(
-			name="Separate objects",
-			description="Import to separate objects instead one large object",
-			default=False
-			)
-
-	@classmethod
-	def poll(cls, context):
-		return context.mode == 'OBJECT'
-
-	def __del__(self):
-		bpy.context.window.cursor_set('DEFAULT')
-
-	def execute(self, context):
-
-		prefs = bpy.context.preferences.addons[PKG].preferences
-
-		#Set cursor representation to 'loading' icon
-		w = context.window
-		w.cursor_set('WAIT')
-		t0 = perf_clock()
-
-		bpy.ops.object.select_all(action='DESELECT')
-
-		#Path
-		shpName = os.path.basename(self.filepath)[:-4]
-
-		#Get shp reader
-		log.info("Read shapefile...")
-		try:
-			shp = shpReader(self.filepath)
-		except Exception as e:
-			log.error("Unable to read shapefile", exc_info=True)
-			self.report({'ERROR'}, "Unable to read shapefile, check logs")
-			return {'CANCELLED'}
-
-		#Check shape type
-		shpType = featureType[shp.shapeType]
-		log.info('Feature type : ' + shpType)
-		if shpType not in ['Point','PolyLine','Polygon','PointZ','PolyLineZ','PolygonZ']:
-			self.report({'ERROR'}, "Cannot process multipoint, multipointZ, pointM, polylineM, polygonM and multipatch feature type")
-			return {'CANCELLED'}
-
-		if self.elevSource != 'FIELD':
-			self.fieldElevName = ''
-
-		if self.elevSource == 'OBJ':
-			scn = bpy.context.scene
-			elevObj = scn.objects[self.objElevName]
-			rayCaster = DropToGround(scn, elevObj)
-
-		#Get fields
-		fields = [field for field in shp.fields if field[0] != 'DeletionFlag'] #ignore default DeletionFlag field
-		fieldsNames = [field[0] for field in fields]
-		log.debug("DBF fields : "+str(fieldsNames))
-
-		if self.separateObjects or self.fieldElevName or self.fieldObjName or self.fieldExtrudeName:
-			self.useDbf = True
-		else:
-			self.useDbf = False
-
-		if self.fieldObjName and self.separateObjects:
-			try:
-				nameFieldIdx = fieldsNames.index(self.fieldObjName)
-			except Exception as e:
-				log.error('Unable to find name field', exc_info=True)
-				self.report({'ERROR'}, "Unable to find name field")
-				return {'CANCELLED'}
-
-		if self.fieldElevName:
-			try:
-				zFieldIdx = fieldsNames.index(self.fieldElevName)
-			except Exception as e:
-				log.error('Unable to find elevation field', exc_info=True)
-				self.report({'ERROR'}, "Unable to find elevation field")
-				return {'CANCELLED'}
-
-			if fields[zFieldIdx][1] not in ['N', 'F', 'L'] :
-				self.report({'ERROR'}, "Elevation field do not contains numeric values")
-				return {'CANCELLED'}
-
-		if self.fieldExtrudeName:
-			try:
-				extrudeFieldIdx = fieldsNames.index(self.fieldExtrudeName)
-			except ValueError:
-				log.error('Unable to find extrusion field', exc_info=True)
-				self.report({'ERROR'}, "Unable to find extrusion field")
-				return {'CANCELLED'}
-
-			if fields[extrudeFieldIdx][1] not in ['N', 'F', 'L'] :
-				self.report({'ERROR'}, "Extrusion field do not contains numeric values")
-				return {'CANCELLED'}
-
-		#Get shp and scene georef infos
-		shpCRS = self.shpCRS
-		geoscn = GeoScene()
-		if geoscn.isBroken:
-			self.report({'ERROR'}, "Scene georef is broken, please fix it beforehand")
-			return {'CANCELLED'}
-
-		scale = geoscn.scale #TODO
-
-		if not geoscn.hasCRS: #if not geoscn.isGeoref:
-			try:
-				geoscn.crs = shpCRS
-			except Exception as e:
-				log.error("Cannot set scene crs", exc_info=True)
-				self.report({'ERROR'}, "Cannot set scene crs, check logs for more infos")
-				return {'CANCELLED'}
-
-		#Init reprojector class
-		if geoscn.crs != shpCRS:
-			log.info("Data will be reprojected from {} to {}".format(shpCRS, geoscn.crs))
-			try:
-				rprj = Reproj(shpCRS, geoscn.crs)
-			except Exception as e:
-				log.error('Reprojection fails', exc_info=True)
-				self.report({'ERROR'}, "Unable to reproject data, check logs for more infos.")
-				return {'CANCELLED'}
-			if rprj.iproj == 'EPSGIO':
-				if shp.numRecords > 100:
-					self.report({'ERROR'}, "Reprojection through online epsg.io engine is limited to 100 features. \nPlease install GDAL or pyproj module.")
-					return {'CANCELLED'}
-
-		#Get bbox
-		bbox = BBOX(shp.bbox)
-		if geoscn.crs != shpCRS:
-			bbox = rprj.bbox(bbox)
-
-		#Get or set georef dx, dy
-		if not geoscn.isGeoref:
-			dx, dy = bbox.center
-			geoscn.setOriginPrj(dx, dy)
-		else:
-			dx, dy = geoscn.getOriginPrj()
-
-		#Get reader iterator (using iterator avoids loading all data in memory)
-		#warn, shp with zero field will return an empty shapeRecords() iterator
-		#to prevent this issue, iter only on shapes if there is no field required
-		if self.useDbf:
-			#Note: using shapeRecord solve the issue where number of shapes does not match number of table records
-			#because it iter only on features with geom and record
-			shpIter = shp.iterShapeRecords()
-		else:
-			shpIter = shp.iterShapes()
-		nbFeats = shp.numRecords
-
-		#Create an empty BMesh
-		bm = bmesh.new()
-		#Extrusion is exponentially slow with large bmesh
-		#it's fastest to extrude a small bmesh and then join it to a final large bmesh
-		if not self.separateObjects and self.fieldExtrudeName:
-			finalBm = bmesh.new()
-
-		progress = -1
-
-		if self.separateObjects:
-			layer = bpy.data.collections.new(shpName)
-			context.scene.collection.children.link(layer)
-
-		#Main iteration over features
-		for i, feat in enumerate(shpIter):
-
-			if self.useDbf:
-				shape = feat.shape
-				record = feat.record
-			else:
-				shape = feat
-
-			#Progress infos
-			pourcent = round(((i+1)*100)/nbFeats)
-			if pourcent in list(range(0, 110, 10)) and pourcent != progress:
-				progress = pourcent
-				if pourcent == 100:
-					print(str(pourcent)+'%')
-				else:
-					print(str(pourcent), end="%, ")
-				sys.stdout.flush() #we need to flush or it won't print anything until after the loop has finished
-
-			#Deal with multipart features
-			#If the shape record has multiple parts, the 'parts' attribute will contains the index of
-			#the first point of each part. If there is only one part then a list containing 0 is returned
-			if (shpType == 'PointZ' or shpType == 'Point'): #point layer has no attribute 'parts'
-				partsIdx = [0]
-			else:
-				try: #prevent "_shape object has no attribute parts" error
-					partsIdx = shape.parts
-				except Exception as e:
-					log.warning('Cannot access "parts" attribute for feature {} : {}'.format(i, e))
-					partsIdx = [0]
-			nbParts = len(partsIdx)
-
-			#Get list of shape's points
-			pts = shape.points
-			nbPts = len(pts)
-
-			#Skip null geom
-			if nbPts == 0:
-				continue #go to next iteration of the loop
-
-			#Reproj geom
-			if geoscn.crs != shpCRS:
-				pts = rprj.pts(pts)
-
-			#Get extrusion offset
-			if self.fieldExtrudeName:
-				try:
-					offset = float(record[extrudeFieldIdx])
-				except Exception as e:
-					log.warning('Cannot extract extrusion value for feature {} : {}'.format(i, e))
-					offset = 0 #null values will be set to zero
-
-			#Iter over parts
-			for j in range(nbParts):
-
-				# EXTRACT 3D GEOM
-
-				geom = [] #will contains a list of 3d points
-
-				#Find first and last part index
-				idx1 = partsIdx[j]
-				if j+1 == nbParts:
-					idx2 = nbPts
-				else:
-					idx2 = partsIdx[j+1]
-
-				#Build 3d geom
-				for k, pt in enumerate(pts[idx1:idx2]):
-
-					if self.elevSource == 'OBJ':
-						rcHit = rayCaster.rayCast(x=pt[0]-dx, y=pt[1]-dy)
-						z = rcHit.loc.z #will be automatically set to zero if not rcHit.hit
-
-					elif self.elevSource == 'FIELD':
-						try:
-							z = float(record[zFieldIdx])
-						except Exception as e:
-							log.warning('Cannot extract elevation value for feature {} : {}'.format(i, e))
-							z = 0 #null values will be set to zero
-
-					elif shpType[-1] == 'Z' and self.elevSource == 'GEOM':
-						z = shape.z[idx1:idx2][k]
-
-					else:
-						z = 0
-
-					geom.append((pt[0], pt[1], z))
-
-				#Shift coords
-				geom = [(pt[0]-dx, pt[1]-dy, pt[2]) for pt in geom]
-
-
-				# BUILD BMESH
-
-				# POINTS
-				if (shpType == 'PointZ' or shpType == 'Point'):
-					vert = [bm.verts.new(pt) for pt in geom]
-					#Extrusion
-					if self.fieldExtrudeName and offset > 0:
-						vect = (0, 0, offset) #along Z
-						result = bmesh.ops.extrude_vert_indiv(bm, verts=vert)
-						verts = result['verts']
-						bmesh.ops.translate(bm, verts=verts, vec=vect)
-
-				# LINES
-				if (shpType == 'PolyLine' or shpType == 'PolyLineZ'):
-					verts = [bm.verts.new(pt) for pt in geom]
-					edges = []
-					for i in range(len(geom)-1):
-						edge = bm.edges.new( [verts[i], verts[i+1] ])
-						edges.append(edge)
-					#Extrusion
-					if self.fieldExtrudeName and offset > 0:
-						vect = (0, 0, offset) # along Z
-						result = bmesh.ops.extrude_edge_only(bm, edges=edges)
-						verts = [elem for elem in result['geom'] if isinstance(elem, bmesh.types.BMVert)]
-						bmesh.ops.translate(bm, verts=verts, vec=vect)
-
-				# NGONS
-				if (shpType == 'Polygon' or shpType == 'PolygonZ'):
-					#According to the shapefile spec, polygons points are clockwise and polygon holes are counterclockwise
-					#in Blender face is up if points are in anticlockwise order
-					geom.reverse() #face up
-					geom.pop() #exlude last point because it's the same as first pt
-					if len(geom) >= 3: #needs 3 points to get a valid face
-						verts = [bm.verts.new(pt) for pt in geom]
-						face = bm.faces.new(verts)
-						#update normal to avoid null vector
-						face.normal_update()
-						if face.normal.z < 0: #this is a polygon hole, bmesh cannot handle polygon hole
-							pass #TODO
-						#Extrusion
-						if self.fieldExtrudeName and offset > 0:
-							#build translate vector
-							if self.extrusionAxis == 'NORMAL':
-								normal = face.normal
-								vect = normal * offset
-							elif self.extrusionAxis == 'Z':
-								vect = (0, 0, offset)
-							faces = bmesh.ops.extrude_discrete_faces(bm, faces=[face]) #return {'faces': [BMFace]}
-							verts = faces['faces'][0].verts
-							if self.elevSource == 'OBJ':
-								# Making flat roof (TODO add an user input parameter to setup this behaviour)
-								z = max([v.co.z for v in verts]) + offset #get max z coord
-								for v in verts:
-									v.co.z = z
-							else:
-								##result = bmesh.ops.extrude_face_region(bm, geom=[face]) #return dict {"geom":[BMVert, BMEdge, BMFace]}
-								##verts = [elem for elem in result['geom'] if isinstance(elem, bmesh.types.BMVert)] #geom type filter
-								bmesh.ops.translate(bm, verts=verts, vec=vect)
-
-
-			if self.separateObjects:
-
-				if self.fieldObjName:
-					try:
-						name = record[nameFieldIdx]
-					except Exception as e:
-						log.warning('Cannot extract name value for feature {} : {}'.format(i, e))
-						name = ''
-					# null values will return a bytes object containing a blank string of length equal to fields length definition
-					if isinstance(name, bytes):
-						name = ''
-					else:
-						name = str(name)
-				else:
-					name = shpName
-
-				#Calc bmesh bbox
-				_bbox = getBBOX.fromBmesh(bm)
-
-				#Calc bmesh geometry origin and translate coords according to it
-				#then object location will be set to initial bmesh origin
-				#its a work around to bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
-				ox, oy, oz = _bbox.center
-				oz = _bbox.zmin
-				bmesh.ops.translate(bm, verts=bm.verts, vec=(-ox, -oy, -oz))
-
-				#Create new mesh from bmesh
-				mesh = bpy.data.meshes.new(name)
-				bm.to_mesh(mesh)
-				bm.clear()
-
-				#Validate new mesh
-				mesh.validate(verbose=False)
-
-				#Place obj
-				obj = bpy.data.objects.new(name, mesh)
-				layer.objects.link(obj)
-				context.view_layer.objects.active = obj
-				obj.select_set(True)
-				obj.location = (ox, oy, oz)
-
-				# bpy operators can be very cumbersome when scene contains lot of objects
-				# because it cause implicit scene updates calls
-				# so we must avoid using operators when created many objects with the 'separate objects' option)
-				##bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
-
-				#write attributes data
-				for i, field in enumerate(shp.fields):
-					fieldName, fieldType, fieldLength, fieldDecLength = field
-					if fieldName != 'DeletionFlag':
-						if fieldType in ('N', 'F'):
-							v = record[i-1]
-							if v is not None:
-								#cast to float to avoid overflow error when affecting custom property
-								obj[fieldName] = float(record[i-1])
-						else:
-							obj[fieldName] = record[i-1]
-
-			elif self.fieldExtrudeName:
-				#Join to final bmesh (use from_mesh method hack)
-				buff = bpy.data.meshes.new(".temp")
-				bm.to_mesh(buff)
-				finalBm.from_mesh(buff)
-				bpy.data.meshes.remove(buff)
-				bm.clear()
-
-		#Write back the whole mesh
-		if not self.separateObjects:
-
-			mesh = bpy.data.meshes.new(shpName)
-
-			if self.fieldExtrudeName:
-				bm.free()
-				bm = finalBm
-
-			if prefs.mergeDoubles:
-				bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.0001)
-			bm.to_mesh(mesh)
-
-			#Finish
-			#mesh.update(calc_edges=True)
-			mesh.validate(verbose=False) #return true if the mesh has been corrected
-			obj = bpy.data.objects.new(shpName, mesh)
-			context.scene.collection.objects.link(obj)
-			context.view_layer.objects.active = obj
-			obj.select_set(True)
-			bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
-
-		#free the bmesh
-		bm.free()
-
-		t = perf_clock() - t0
-		log.info('Build in %f seconds' % t)
-
-		#Adjust grid size
-		if prefs.adjust3Dview:
-			bbox.shift(-dx, -dy) #convert shapefile bbox in 3d view space
-			adjust3Dview(context, bbox)
-
-
-		return {'FINISHED'}
+        """Import from ESRI shapefile file format (.shp)"""
+
+        bl_idname = "importgis.shapefile" # important since its how bpy.ops.import.shapefile is constructed (allows calling operator from python console or another script)
+        #bl_idname rules: must contain one '.' (dot) charactere, no capital letters, no reserved words (like 'import')
+        bl_description = 'Import ESRI shapefile (.shp)'
+        bl_label = "Import SHP"
+        bl_options = {"UNDO"}
+
+        filepath: StringProperty()
+
+        shpCRS: StringProperty(name = "Shapefile CRS", description = "Coordinate Reference System")
+
+        elevSource: StringProperty(name = "Elevation source", description = "Elevation source", default='GEOM') # [NONE, GEOM, OBJ, FIELD]
+        objElevName: StringProperty(name = "Elevation object name", description = "")
+
+        fieldElevName: StringProperty(name = "Elevation field", description = "Field name")
+        fieldExtrudeName: StringProperty(name = "Extrusion field", description = "Field name")
+        fieldObjName: StringProperty(name = "Objects names field", description = "Field name")
+
+        #Extrusion axis
+        extrusionAxis: EnumProperty(
+                        name="Extrude along",
+                        description="Select extrusion axis",
+                        items=[ ('Z', 'z axis', "Extrude along Z axis"),
+                        ('NORMAL', 'Normal', "Extrude along normal")]
+                        )
+        #Create separate objects
+        separateObjects: BoolProperty(
+                        name="Separate objects",
+                        description="Import to separate objects instead one large object",
+                        default=False
+                        )
+
+        @classmethod
+        def poll(cls, context):
+                return context.mode == 'OBJECT'
+
+        def __del__(self):
+                bpy.context.window.cursor_set('DEFAULT')
+
+        def execute(self, context):
+
+                prefs = bpy.context.preferences.addons[PKG].preferences
+
+                #Set cursor representation to 'loading' icon
+                w = context.window
+                w.cursor_set('WAIT')
+                t0 = perf_clock()
+
+                bpy.ops.object.select_all(action='DESELECT')
+
+                #Path
+                shpName = os.path.basename(self.filepath)[:-4]
+
+                #Get shp reader
+                log.info("Read shapefile...")
+                try:
+                        shp = shpReader(self.filepath)
+                except Exception as e:
+                        log.error("Unable to read shapefile", exc_info=True)
+                        self.report({'ERROR'}, "Unable to read shapefile, check logs")
+                        return {'CANCELLED'}
+
+                #Check shape type
+                shpType = featureType[shp.shapeType]
+                log.info('Feature type : ' + shpType)
+                if shpType not in ['Point','PolyLine','Polygon','PointZ','PolyLineZ','PolygonZ']:
+                        self.report({'ERROR'}, "Cannot process multipoint, multipointZ, pointM, polylineM, polygonM and multipatch feature type")
+                        return {'CANCELLED'}
+
+                if self.elevSource != 'FIELD':
+                        self.fieldElevName = ''
+
+                if self.elevSource == 'OBJ':
+                        scn = bpy.context.scene
+                        elevObj = scn.objects[self.objElevName]
+                        rayCaster = DropToGround(scn, elevObj)
+
+                #Get fields
+                fields = [field for field in shp.fields if field[0] != 'DeletionFlag'] #ignore default DeletionFlag field
+                fieldsNames = [field[0] for field in fields]
+                log.debug("DBF fields : "+str(fieldsNames))
+
+                if self.separateObjects or self.fieldElevName or self.fieldObjName or self.fieldExtrudeName:
+                        self.useDbf = True
+                else:
+                        self.useDbf = False
+
+                if self.fieldObjName and self.separateObjects:
+                        try:
+                                nameFieldIdx = fieldsNames.index(self.fieldObjName)
+                        except Exception as e:
+                                log.error('Unable to find name field', exc_info=True)
+                                self.report({'ERROR'}, "Unable to find name field")
+                                return {'CANCELLED'}
+
+                if self.fieldElevName:
+                        try:
+                                zFieldIdx = fieldsNames.index(self.fieldElevName)
+                        except Exception as e:
+                                log.error('Unable to find elevation field', exc_info=True)
+                                self.report({'ERROR'}, "Unable to find elevation field")
+                                return {'CANCELLED'}
+
+                        if fields[zFieldIdx][1] not in ['N', 'F', 'L'] :
+                                self.report({'ERROR'}, "Elevation field do not contains numeric values")
+                                return {'CANCELLED'}
+
+                if self.fieldExtrudeName:
+                        try:
+                                extrudeFieldIdx = fieldsNames.index(self.fieldExtrudeName)
+                        except ValueError:
+                                log.error('Unable to find extrusion field', exc_info=True)
+                                self.report({'ERROR'}, "Unable to find extrusion field")
+                                return {'CANCELLED'}
+
+                        if fields[extrudeFieldIdx][1] not in ['N', 'F', 'L'] :
+                                self.report({'ERROR'}, "Extrusion field do not contains numeric values")
+                                return {'CANCELLED'}
+
+                #Get shp and scene georef infos
+                shpCRS = self.shpCRS
+                geoscn = GeoScene()
+                if geoscn.isBroken:
+                        self.report({'ERROR'}, "Scene georef is broken, please fix it beforehand")
+                        return {'CANCELLED'}
+
+                scale = geoscn.scale #TODO
+
+                if not geoscn.hasCRS: #if not geoscn.isGeoref:
+                        try:
+                                geoscn.crs = shpCRS
+                        except Exception as e:
+                                log.error("Cannot set scene crs", exc_info=True)
+                                self.report({'ERROR'}, "Cannot set scene crs, check logs for more infos")
+                                return {'CANCELLED'}
+
+                #Init reprojector class
+                if geoscn.crs != shpCRS:
+                        log.info("Data will be reprojected from {} to {}".format(shpCRS, geoscn.crs))
+                        try:
+                                rprj = Reproj(shpCRS, geoscn.crs)
+                        except Exception as e:
+                                log.error('Reprojection fails', exc_info=True)
+                                self.report({'ERROR'}, "Unable to reproject data, check logs for more infos.")
+                                return {'CANCELLED'}
+                        if rprj.iproj == 'EPSGIO' and shp.numRecords > EPSGIO.MAX_POINTS:
+                                self.report({'WARNING'}, f"Reprojection through epsg.io will be chunked in batches of {EPSGIO.MAX_POINTS} features and may be slow.")
+
+                #Get bbox
+                bbox = BBOX(shp.bbox)
+                if geoscn.crs != shpCRS:
+                        bbox = rprj.bbox(bbox)
+
+                #Get or set georef dx, dy
+                if not geoscn.isGeoref:
+                        dx, dy = bbox.center
+                        geoscn.setOriginPrj(dx, dy)
+                else:
+                        dx, dy = geoscn.getOriginPrj()
+
+                #Get reader iterator (using iterator avoids loading all data in memory)
+                #warn, shp with zero field will return an empty shapeRecords() iterator
+                #to prevent this issue, iter only on shapes if there is no field required
+                if self.useDbf:
+                        #Note: using shapeRecord solve the issue where number of shapes does not match number of table records
+                        #because it iter only on features with geom and record
+                        shpIter = shp.iterShapeRecords()
+                else:
+                        shpIter = shp.iterShapes()
+                nbFeats = shp.numRecords
+
+                #Create an empty BMesh
+                bm = bmesh.new()
+                #Extrusion is exponentially slow with large bmesh
+                #it's fastest to extrude a small bmesh and then join it to a final large bmesh
+                if not self.separateObjects and self.fieldExtrudeName:
+                        finalBm = bmesh.new()
+
+                progress = -1
+
+                if self.separateObjects:
+                        layer = bpy.data.collections.new(shpName)
+                        context.scene.collection.children.link(layer)
+
+                #Main iteration over features
+                for i, feat in enumerate(shpIter):
+
+                        if self.useDbf:
+                                shape = feat.shape
+                                record = feat.record
+                        else:
+                                shape = feat
+
+                        #Progress infos
+                        pourcent = round(((i+1)*100)/nbFeats)
+                        if pourcent in list(range(0, 110, 10)) and pourcent != progress:
+                                progress = pourcent
+                                if pourcent == 100:
+                                        print(str(pourcent)+'%')
+                                else:
+                                        print(str(pourcent), end="%, ")
+                                sys.stdout.flush() #we need to flush or it won't print anything until after the loop has finished
+
+                        #Deal with multipart features
+                        #If the shape record has multiple parts, the 'parts' attribute will contains the index of
+                        #the first point of each part. If there is only one part then a list containing 0 is returned
+                        if (shpType == 'PointZ' or shpType == 'Point'): #point layer has no attribute 'parts'
+                                partsIdx = [0]
+                        else:
+                                try: #prevent "_shape object has no attribute parts" error
+                                        partsIdx = shape.parts
+                                except Exception as e:
+                                        log.warning('Cannot access "parts" attribute for feature {} : {}'.format(i, e))
+                                        partsIdx = [0]
+                        nbParts = len(partsIdx)
+
+                        #Get list of shape's points
+                        pts = shape.points
+                        nbPts = len(pts)
+
+                        #Skip null geom
+                        if nbPts == 0:
+                                continue #go to next iteration of the loop
+
+                        #Reproj geom
+                        if geoscn.crs != shpCRS:
+                                pts = rprj.pts(pts)
+
+                        #Get extrusion offset
+                        if self.fieldExtrudeName:
+                                try:
+                                        offset = float(record[extrudeFieldIdx])
+                                except Exception as e:
+                                        log.warning('Cannot extract extrusion value for feature {} : {}'.format(i, e))
+                                        offset = 0 #null values will be set to zero
+
+                        #Iter over parts
+                        for j in range(nbParts):
+
+                                # EXTRACT 3D GEOM
+
+                                geom = [] #will contains a list of 3d points
+
+                                #Find first and last part index
+                                idx1 = partsIdx[j]
+                                if j+1 == nbParts:
+                                        idx2 = nbPts
+                                else:
+                                        idx2 = partsIdx[j+1]
+
+                                #Build 3d geom
+                                for k, pt in enumerate(pts[idx1:idx2]):
+
+                                        if self.elevSource == 'OBJ':
+                                                rcHit = rayCaster.rayCast(x=pt[0]-dx, y=pt[1]-dy)
+                                                z = rcHit.loc.z #will be automatically set to zero if not rcHit.hit
+
+                                        elif self.elevSource == 'FIELD':
+                                                try:
+                                                        z = float(record[zFieldIdx])
+                                                except Exception as e:
+                                                        log.warning('Cannot extract elevation value for feature {} : {}'.format(i, e))
+                                                        z = 0 #null values will be set to zero
+
+                                        elif shpType[-1] == 'Z' and self.elevSource == 'GEOM':
+                                                z = shape.z[idx1:idx2][k]
+
+                                        else:
+                                                z = 0
+
+                                        geom.append((pt[0], pt[1], z))
+
+                                #Shift coords
+                                geom = [(pt[0]-dx, pt[1]-dy, pt[2]) for pt in geom]
+
+
+                                # BUILD BMESH
+
+                                # POINTS
+                                if (shpType == 'PointZ' or shpType == 'Point'):
+                                        vert = [bm.verts.new(pt) for pt in geom]
+                                        #Extrusion
+                                        if self.fieldExtrudeName and offset > 0:
+                                                vect = (0, 0, offset) #along Z
+                                                result = bmesh.ops.extrude_vert_indiv(bm, verts=vert)
+                                                verts = result['verts']
+                                                bmesh.ops.translate(bm, verts=verts, vec=vect)
+
+                                # LINES
+                                if (shpType == 'PolyLine' or shpType == 'PolyLineZ'):
+                                        verts = [bm.verts.new(pt) for pt in geom]
+                                        edges = []
+                                        for i in range(len(geom)-1):
+                                                edge = bm.edges.new( [verts[i], verts[i+1] ])
+                                                edges.append(edge)
+                                        #Extrusion
+                                        if self.fieldExtrudeName and offset > 0:
+                                                vect = (0, 0, offset) # along Z
+                                                result = bmesh.ops.extrude_edge_only(bm, edges=edges)
+                                                verts = [elem for elem in result['geom'] if isinstance(elem, bmesh.types.BMVert)]
+                                                bmesh.ops.translate(bm, verts=verts, vec=vect)
+
+                                # NGONS
+                                if (shpType == 'Polygon' or shpType == 'PolygonZ'):
+                                        #According to the shapefile spec, polygons points are clockwise and polygon holes are counterclockwise
+                                        #in Blender face is up if points are in anticlockwise order
+                                        geom.reverse() #face up
+                                        geom.pop() #exlude last point because it's the same as first pt
+                                        if len(geom) >= 3: #needs 3 points to get a valid face
+                                                verts = [bm.verts.new(pt) for pt in geom]
+                                                face = bm.faces.new(verts)
+                                                #update normal to avoid null vector
+                                                face.normal_update()
+                                                if face.normal.z < 0: #this is a polygon hole, bmesh cannot handle polygon hole
+                                                        pass #TODO
+                                                #Extrusion
+                                                if self.fieldExtrudeName and offset > 0:
+                                                        #build translate vector
+                                                        if self.extrusionAxis == 'NORMAL':
+                                                                normal = face.normal
+                                                                vect = normal * offset
+                                                        elif self.extrusionAxis == 'Z':
+                                                                vect = (0, 0, offset)
+                                                        faces = bmesh.ops.extrude_discrete_faces(bm, faces=[face]) #return {'faces': [BMFace]}
+                                                        verts = faces['faces'][0].verts
+                                                        if self.elevSource == 'OBJ':
+                                                                # Making flat roof (TODO add an user input parameter to setup this behaviour)
+                                                                z = max([v.co.z for v in verts]) + offset #get max z coord
+                                                                for v in verts:
+                                                                        v.co.z = z
+                                                        else:
+                                                                ##result = bmesh.ops.extrude_face_region(bm, geom=[face]) #return dict {"geom":[BMVert, BMEdge, BMFace]}
+                                                                ##verts = [elem for elem in result['geom'] if isinstance(elem, bmesh.types.BMVert)] #geom type filter
+                                                                bmesh.ops.translate(bm, verts=verts, vec=vect)
+
+
+                        if self.separateObjects:
+
+                                if self.fieldObjName:
+                                        try:
+                                                name = record[nameFieldIdx]
+                                        except Exception as e:
+                                                log.warning('Cannot extract name value for feature {} : {}'.format(i, e))
+                                                name = ''
+                                        # null values will return a bytes object containing a blank string of length equal to fields length definition
+                                        if isinstance(name, bytes):
+                                                name = ''
+                                        else:
+                                                name = str(name)
+                                else:
+                                        name = shpName
+
+                                #Calc bmesh bbox
+                                _bbox = getBBOX.fromBmesh(bm)
+
+                                #Calc bmesh geometry origin and translate coords according to it
+                                #then object location will be set to initial bmesh origin
+                                #its a work around to bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
+                                ox, oy, oz = _bbox.center
+                                oz = _bbox.zmin
+                                bmesh.ops.translate(bm, verts=bm.verts, vec=(-ox, -oy, -oz))
+
+                                #Create new mesh from bmesh
+                                mesh = bpy.data.meshes.new(name)
+                                bm.to_mesh(mesh)
+                                bm.clear()
+
+                                #Validate new mesh
+                                mesh.validate(verbose=False)
+
+                                #Place obj
+                                obj = bpy.data.objects.new(name, mesh)
+                                layer.objects.link(obj)
+                                context.view_layer.objects.active = obj
+                                obj.select_set(True)
+                                obj.location = (ox, oy, oz)
+
+                                # bpy operators can be very cumbersome when scene contains lot of objects
+                                # because it cause implicit scene updates calls
+                                # so we must avoid using operators when created many objects with the 'separate objects' option)
+                                ##bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
+
+                                #write attributes data
+                                for i, field in enumerate(shp.fields):
+                                        fieldName, fieldType, fieldLength, fieldDecLength = field
+                                        if fieldName != 'DeletionFlag':
+                                                if fieldType in ('N', 'F'):
+                                                        v = record[i-1]
+                                                        if v is not None:
+                                                                #cast to float to avoid overflow error when affecting custom property
+                                                                obj[fieldName] = float(record[i-1])
+                                                else:
+                                                        obj[fieldName] = record[i-1]
+
+                        elif self.fieldExtrudeName:
+                                #Join to final bmesh (use from_mesh method hack)
+                                buff = bpy.data.meshes.new(".temp")
+                                bm.to_mesh(buff)
+                                finalBm.from_mesh(buff)
+                                bpy.data.meshes.remove(buff)
+                                bm.clear()
+
+                #Write back the whole mesh
+                if not self.separateObjects:
+
+                        mesh = bpy.data.meshes.new(shpName)
+
+                        if self.fieldExtrudeName:
+                                bm.free()
+                                bm = finalBm
+
+                        if prefs.mergeDoubles:
+                                bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.0001)
+                        bm.to_mesh(mesh)
+
+                        #Finish
+                        #mesh.update(calc_edges=True)
+                        mesh.validate(verbose=False) #return true if the mesh has been corrected
+                        obj = bpy.data.objects.new(shpName, mesh)
+                        context.scene.collection.objects.link(obj)
+                        context.view_layer.objects.active = obj
+                        obj.select_set(True)
+                        bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
+
+                #free the bmesh
+                bm.free()
+
+                t = perf_clock() - t0
+                log.info('Build in %f seconds' % t)
+
+                #Adjust grid size
+                if prefs.adjust3Dview:
+                        bbox.shift(-dx, -dy) #convert shapefile bbox in 3d view space
+                        adjust3Dview(context, bbox)
+
+
+                return {'FINISHED'}
 
 classes = [
-	IMPORTGIS_OT_shapefile_file_dialog,
-	IMPORTGIS_OT_shapefile_props_dialog,
-	IMPORTGIS_OT_shapefile
+        IMPORTGIS_OT_shapefile_file_dialog,
+        IMPORTGIS_OT_shapefile_props_dialog,
+        IMPORTGIS_OT_shapefile
 ]
 
 def register():
-	for cls in classes:
-		try:
-			bpy.utils.register_class(cls)
-		except ValueError as e:
-			log.warning('{} is already registered, now unregister and retry... '.format(cls))
-			bpy.utils.unregister_class(cls)
-			bpy.utils.register_class(cls)
+        for cls in classes:
+                try:
+                        bpy.utils.register_class(cls)
+                except ValueError as e:
+                        log.warning('{} is already registered, now unregister and retry... '.format(cls))
+                        bpy.utils.unregister_class(cls)
+                        bpy.utils.register_class(cls)
 
 def unregister():
-	for cls in classes:
-		bpy.utils.unregister_class(cls)
+        for cls in classes:
+                bpy.utils.unregister_class(cls)

--- a/prefs.py
+++ b/prefs.py
@@ -17,11 +17,11 @@ from .core import settings
 PKG = __package__
 
 def getAppData():
-	home = os.path.expanduser('~')
-	loc = os.path.join(home, '.bgis')
-	if not os.path.exists(loc):
-		os.mkdir(loc)
-	return loc
+        home = os.path.expanduser('~')
+        loc = os.path.join(home, '.bgis')
+        if not os.path.exists(loc):
+                os.mkdir(loc)
+        return loc
 
 APP_DATA = getAppData()
 
@@ -36,787 +36,800 @@ As the json backend is stored in addon preferences, the property will be saved a
 
 
 DEFAULT_CRS = [
-	('EPSG:3857', 'Web Mercator', 'Worldwide projection, high distortions, not suitable for precision modelling'),
-	('EPSG:4326', 'WGS84 latlon', 'Longitude and latitude in degrees, DO NOT USE AS SCENE CRS (this system is defined only for reprojection tasks')
+        ('EPSG:3857', 'Web Mercator', 'Worldwide projection, high distortions, not suitable for precision modelling'),
+        ('EPSG:4326', 'WGS84 latlon', 'Longitude and latitude in degrees, DO NOT USE AS SCENE CRS (this system is defined only for reprojection tasks')
 ]
 
 
 DEFAULT_DEM_SERVER = [
-	("https://portal.opentopography.org/API/globaldem?demtype=SRTMGL1&west={W}&east={E}&south={S}&north={N}&outputFormat=GTiff&API_Key={API_KEY}", 'OpenTopography SRTM 30m', 'OpenTopography.org web service for SRTM 30m global DEM'),
-	("https://portal.opentopography.org/API/globaldem?demtype=SRTMGL3&west={W}&east={E}&south={S}&north={N}&outputFormat=GTiff&API_Key={API_KEY}", 'OpenTopography SRTM 90m', 'OpenTopography.org web service for SRTM 90m global DEM'),
-	("http://www.gmrt.org/services/GridServer?west={W}&east={E}&south={S}&north={N}&layer=topo&format=geotiff&resolution=high", 'Marine-geo.org GMRT', 'Marine-geo.org web service for GMRT global DEM (terrestrial (ASTER) and bathymetry)')
+        ("https://portal.opentopography.org/API/globaldem?demtype=SRTMGL1&west={W}&east={E}&south={S}&north={N}&outputFormat=GTiff&API_Key={API_KEY}", 'OpenTopography SRTM 30m', 'OpenTopography.org web service for SRTM 30m global DEM'),
+        ("https://portal.opentopography.org/API/globaldem?demtype=SRTMGL3&west={W}&east={E}&south={S}&north={N}&outputFormat=GTiff&API_Key={API_KEY}", 'OpenTopography SRTM 90m', 'OpenTopography.org web service for SRTM 90m global DEM'),
+        ("http://www.gmrt.org/services/GridServer?west={W}&east={E}&south={S}&north={N}&layer=topo&format=geotiff&resolution=high", 'Marine-geo.org GMRT', 'Marine-geo.org web service for GMRT global DEM (terrestrial (ASTER) and bathymetry)')
 ]
 
 DEFAULT_OVERPASS_SERVER =  [
-	("https://lz4.overpass-api.de/api/interpreter", 'overpass-api.de', 'Main Overpass API instance'),
-	("http://overpass.openstreetmap.fr/api/interpreter", 'overpass.openstreetmap.fr', 'French Overpass API instance'),
-	("https://overpass.kumi.systems/api/interpreter", 'overpass.kumi.systems', 'Kumi Systems Overpass Instance')
+        ("https://lz4.overpass-api.de/api/interpreter", 'overpass-api.de', 'Main Overpass API instance'),
+        ("http://overpass.openstreetmap.fr/api/interpreter", 'overpass.openstreetmap.fr', 'French Overpass API instance'),
+        ("https://overpass.kumi.systems/api/interpreter", 'overpass.kumi.systems', 'Kumi Systems Overpass Instance')
 ]
 
 #default filter tags for OSM import
 DEFAULT_OSM_TAGS = [
-	'building',
-	'highway',
-	'landuse',
-	'leisure',
-	'natural',
-	'railway',
-	'waterway'
+        'building',
+        'highway',
+        'landuse',
+        'leisure',
+        'natural',
+        'railway',
+        'waterway'
 ]
 
 
 
 class BGIS_OT_pref_show(Operator):
 
-	bl_idname = "bgis.pref_show"
-	bl_description = 'Display BlenderGIS addons preferences'
-	bl_label = "Preferences"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.pref_show"
+        bl_description = 'Display BlenderGIS addons preferences'
+        bl_label = "Preferences"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		addon_utils.modules_refresh()
-		context.preferences.active_section = 'ADDONS'
-		bpy.data.window_managers["WinMan"].addon_search = bl_info['name']
-		#bpy.ops.wm.addon_expand(module=PKG)
-		mod = addon_utils.addons_fake_modules.get(PKG)
-		mod.bl_info['show_expanded'] = True
-		bpy.ops.screen.userpref_show('INVOKE_DEFAULT')
-		return {'FINISHED'}
+        def execute(self, context):
+                addon_utils.modules_refresh()
+                context.preferences.active_section = 'ADDONS'
+                bpy.data.window_managers["WinMan"].addon_search = bl_info['name']
+                #bpy.ops.wm.addon_expand(module=PKG)
+                mod = addon_utils.addons_fake_modules.get(PKG)
+                mod.bl_info['show_expanded'] = True
+                bpy.ops.screen.userpref_show('INVOKE_DEFAULT')
+                return {'FINISHED'}
 
 
 
 class BGIS_PREFS(AddonPreferences):
 
-	bl_idname = PKG
+        bl_idname = PKG
 
-	################
-	#Predefined Spatial Ref. Systems
+        ################
+        #Predefined Spatial Ref. Systems
 
-	def listPredefCRS(self, context):
-		return [tuple(elem) for elem in json.loads(self.predefCrsJson)]
+        def listPredefCRS(self, context):
+                return [tuple(elem) for elem in json.loads(self.predefCrsJson)]
 
-	#store crs preset as json string into addon preferences
-	predefCrsJson: StringProperty(default=json.dumps(DEFAULT_CRS))
+        #store crs preset as json string into addon preferences
+        predefCrsJson: StringProperty(default=json.dumps(DEFAULT_CRS))
 
-	predefCrs: EnumProperty(
-		name = "Predefinate CRS",
-		description = "Choose predefinite Coordinate Reference System",
-		#default = 1, #possible only since Blender 2.90
-		items = listPredefCRS
-		)
+        predefCrs: EnumProperty(
+                name = "Predefinate CRS",
+                description = "Choose predefinite Coordinate Reference System",
+                #default = 1, #possible only since Blender 2.90
+                items = listPredefCRS
+                )
 
-	################
-	#proj engine
+        ################
+        #proj engine
 
-	def getProjEngineItems(self, context):
-		items = [ ('AUTO', 'Auto detect', 'Auto select the best library for reprojection tasks') ]
-		if HAS_GDAL:
-			items.append( ('GDAL', 'GDAL', 'Force GDAL as reprojection engine') )
-		if HAS_PYPROJ:
-			items.append( ('PYPROJ', 'pyProj', 'Force pyProj as reprojection engine') )
-		#if EPSGIO.ping(): #too slow
-		#	items.append( ('EPSGIO', 'epsg.io', '') )
-		items.append( ('EPSGIO', 'epsg.io', 'Force epsg.io as reprojection engine') )
-		items.append( ('BUILTIN', 'Built in', 'Force reprojection through built in Python functions') )
-		return items
+        def getProjEngineItems(self, context):
+                items = [ ('AUTO', 'Auto detect', 'Auto select the best library for reprojection tasks') ]
+                if HAS_GDAL:
+                        items.append( ('GDAL', 'GDAL', 'Force GDAL as reprojection engine') )
+                if HAS_PYPROJ:
+                        items.append( ('PYPROJ', 'pyProj', 'Force pyProj as reprojection engine') )
+                #if EPSGIO.ping(): #too slow
+                #        items.append( ('EPSGIO', 'epsg.io', '') )
+                items.append( ('EPSGIO', 'epsg.io', 'Force epsg.io as reprojection engine') )
+                items.append( ('BUILTIN', 'Built in', 'Force reprojection through built in Python functions') )
+                return items
 
-	def updateProjEngine(self, context):
-		settings.proj_engine = self.projEngine
+        def updateProjEngine(self, context):
+                settings.proj_engine = self.projEngine
 
-	projEngine: EnumProperty(
-		name = "Projection engine",
-		description = "Select projection engine",
-		items = getProjEngineItems,
-		update = updateProjEngine
-		)
+        projEngine: EnumProperty(
+                name = "Projection engine",
+                description = "Select projection engine",
+                items = getProjEngineItems,
+                update = updateProjEngine
+                )
 
-	################
-	#img engine
+        def updateEpsgioKey(self, context):
+                settings.epsgio_key = self.epsgioKey
 
-	def getImgEngineItems(self, context):
-		items = [ ('AUTO', 'Auto detect', 'Auto select the best imaging library') ]
-		if HAS_GDAL:
-			items.append( ('GDAL', 'GDAL', 'Force GDAL as image processing engine') )
-		if HAS_IMGIO:
-			items.append( ('IMGIO', 'ImageIO', 'Force ImageIO as image processing  engine') )
-		if HAS_PIL:
-			items.append( ('PIL', 'PIL', 'Force PIL as image processing  engine') )
-		return items
+        epsgioKey: StringProperty(
+                name = "epsg.io API key",
+                description = "Optional API key for epsg.io reprojection service",
+                default = "",
+                update = updateEpsgioKey
+                )
 
-	def updateImgEngine(self, context):
-		settings.img_engine = self.imgEngine
+        ################
+        #img engine
 
-	imgEngine: EnumProperty(
-		name = "Image processing engine",
-		description = "Select image processing engine",
-		items = getImgEngineItems,
-		update = updateImgEngine
-		)
+        def getImgEngineItems(self, context):
+                items = [ ('AUTO', 'Auto detect', 'Auto select the best imaging library') ]
+                if HAS_GDAL:
+                        items.append( ('GDAL', 'GDAL', 'Force GDAL as image processing engine') )
+                if HAS_IMGIO:
+                        items.append( ('IMGIO', 'ImageIO', 'Force ImageIO as image processing  engine') )
+                if HAS_PIL:
+                        items.append( ('PIL', 'PIL', 'Force PIL as image processing  engine') )
+                return items
 
-	################
-	#OSM
+        def updateImgEngine(self, context):
+                settings.img_engine = self.imgEngine
 
-	osmTagsJson: StringProperty(default=json.dumps(DEFAULT_OSM_TAGS)) #just a serialized list of tags
+        imgEngine: EnumProperty(
+                name = "Image processing engine",
+                description = "Select image processing engine",
+                items = getImgEngineItems,
+                update = updateImgEngine
+                )
 
-	def listOsmTags(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		tags = json.loads(prefs.osmTagsJson)
-		#put each item in a tuple (key, label, tooltip)
-		return [ (tag, tag, tag) for tag in tags]
+        ################
+        #OSM
 
-	osmTags: EnumProperty(
-		name = "OSM tags",
-		description = "List of registered OSM tags",
-		items = listOsmTags
-		)
+        osmTagsJson: StringProperty(default=json.dumps(DEFAULT_OSM_TAGS)) #just a serialized list of tags
 
-	################
-	#Basemaps
+        def listOsmTags(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                tags = json.loads(prefs.osmTagsJson)
+                #put each item in a tuple (key, label, tooltip)
+                return [ (tag, tag, tag) for tag in tags]
 
-	def getCacheFolder(self):
-		return bpy.path.abspath(self.get("cacheFolder", ''))
+        osmTags: EnumProperty(
+                name = "OSM tags",
+                description = "List of registered OSM tags",
+                items = listOsmTags
+                )
 
-	def setCacheFolder(self, value):
-		if os.access(value, os.X_OK | os.W_OK):
-			self["cacheFolder"] = value
-		else:
-			log.error("The selected cache folder has no write access")
-			self["cacheFolder"] = "The selected folder has no write access"
+        ################
+        #Basemaps
 
-	cacheFolder: StringProperty(
-		name = "Cache folder",
-		default = APP_DATA, #Does not works !?
-		description = "Define a folder where to store Geopackage SQlite db",
-		subtype = 'DIR_PATH',
-		get = getCacheFolder,
-		set = setCacheFolder
-		)
+        def getCacheFolder(self):
+                return bpy.path.abspath(self.get("cacheFolder", ''))
 
-	synchOrj: BoolProperty(
-		name="Synch. lat/long",
-		description='Keep geo origin synchronized with crs origin. Can be slow with remote reprojection services',
-		default=True)
+        def setCacheFolder(self, value):
+                if os.access(value, os.X_OK | os.W_OK):
+                        self["cacheFolder"] = value
+                else:
+                        log.error("The selected cache folder has no write access")
+                        self["cacheFolder"] = "The selected folder has no write access"
 
-	zoomToMouse: BoolProperty(name="Zoom to mouse", description='Zoom towards the mouse pointer position', default=True)
+        cacheFolder: StringProperty(
+                name = "Cache folder",
+                default = APP_DATA, #Does not works !?
+                description = "Define a folder where to store Geopackage SQlite db",
+                subtype = 'DIR_PATH',
+                get = getCacheFolder,
+                set = setCacheFolder
+                )
 
-	lockOrigin: BoolProperty(name="Lock origin", description='Do not move scene origin when panning map', default=False)
-	lockObj: BoolProperty(name="Lock objects", description='Retain objects geolocation when moving map origin', default=True)
+        synchOrj: BoolProperty(
+                name="Synch. lat/long",
+                description='Keep geo origin synchronized with crs origin. Can be slow with remote reprojection services',
+                default=True)
 
-	resamplAlg: EnumProperty(
-		name = "Resampling method",
-		description = "Choose GDAL's resampling method used for reprojection",
-		items = [ ('NN', 'Nearest Neighboor', ''), ('BL', 'Bilinear', ''), ('CB', 'Cubic', ''), ('CBS', 'Cubic Spline', ''), ('LCZ', 'Lanczos', '') ]
-		)
+        zoomToMouse: BoolProperty(name="Zoom to mouse", description='Zoom towards the mouse pointer position', default=True)
 
-	################
-	#Network
+        lockOrigin: BoolProperty(name="Lock origin", description='Do not move scene origin when panning map', default=False)
+        lockObj: BoolProperty(name="Lock objects", description='Retain objects geolocation when moving map origin', default=True)
 
-	def listOverpassServer(self, context):
-		return [tuple(entry) for entry in json.loads(self.overpassServerJson)]
+        resamplAlg: EnumProperty(
+                name = "Resampling method",
+                description = "Choose GDAL's resampling method used for reprojection",
+                items = [ ('NN', 'Nearest Neighboor', ''), ('BL', 'Bilinear', ''), ('CB', 'Cubic', ''), ('CBS', 'Cubic Spline', ''), ('LCZ', 'Lanczos', '') ]
+                )
 
-	#store crs preset as json string into addon preferences
-	overpassServerJson: StringProperty(default=json.dumps(DEFAULT_OVERPASS_SERVER))
+        ################
+        #Network
 
-	overpassServer: EnumProperty(
-		name = "Overpass server",
-		description = "Select an overpass server",
-		#default = 0,
-		items = listOverpassServer
-		)
+        def listOverpassServer(self, context):
+                return [tuple(entry) for entry in json.loads(self.overpassServerJson)]
 
-	def listDemServer(self, context):
-		return [tuple(entry) for entry in json.loads(self.demServerJson)]
+        #store crs preset as json string into addon preferences
+        overpassServerJson: StringProperty(default=json.dumps(DEFAULT_OVERPASS_SERVER))
 
-	#store crs preset as json string into addon preferences
-	demServerJson: StringProperty(default=json.dumps(DEFAULT_DEM_SERVER))
+        overpassServer: EnumProperty(
+                name = "Overpass server",
+                description = "Select an overpass server",
+                #default = 0,
+                items = listOverpassServer
+                )
 
-	demServer: EnumProperty(
-		name = "Elevation server",
-		description = "Select a server that provides Digital Elevation Model datasource",
-		#default = 0,
-		items = listDemServer
-		)
+        def listDemServer(self, context):
+                return [tuple(entry) for entry in json.loads(self.demServerJson)]
 
-	opentopography_api_key: StringProperty(
-		name = "",
-		description="you need to register and request a key from opentopography website"
-	)
+        #store crs preset as json string into addon preferences
+        demServerJson: StringProperty(default=json.dumps(DEFAULT_DEM_SERVER))
+
+        demServer: EnumProperty(
+                name = "Elevation server",
+                description = "Select a server that provides Digital Elevation Model datasource",
+                #default = 0,
+                items = listDemServer
+                )
+
+        opentopography_api_key: StringProperty(
+                name = "",
+                description="you need to register and request a key from opentopography website"
+        )
 
 
-	################
-	#IO options
-	mergeDoubles: BoolProperty(
-		name = "Merge duplicate vertices",
-		description = 'Merge shared vertices between features when importing vector data',
-		default = False)
-	adjust3Dview: BoolProperty(
-		name = "Adjust 3D view",
-		description = "Update 3d view grid size and clip distances according to the new imported object's size",
-		default = True)
-	forceTexturedSolid: BoolProperty(
-		name = "Force textured solid shading",
-		description = "Update shading mode to display raster's texture",
-		default = True)
+        ################
+        #IO options
+        mergeDoubles: BoolProperty(
+                name = "Merge duplicate vertices",
+                description = 'Merge shared vertices between features when importing vector data',
+                default = False)
+        adjust3Dview: BoolProperty(
+                name = "Adjust 3D view",
+                description = "Update 3d view grid size and clip distances according to the new imported object's size",
+                default = True)
+        forceTexturedSolid: BoolProperty(
+                name = "Force textured solid shading",
+                description = "Update shading mode to display raster's texture",
+                default = True)
 
-	################
-	#System
-	def updateLogLevel(self, context):
-		logger = logging.getLogger(PKG)
-		logger.setLevel(logging.getLevelName(self.logLevel))
+        ################
+        #System
+        def updateLogLevel(self, context):
+                logger = logging.getLogger(PKG)
+                logger.setLevel(logging.getLevelName(self.logLevel))
 
-	logLevel: EnumProperty(
-		name = "Logging level",
-		description = "Select the logging level",
-		items = [('DEBUG', 'Debug', ''), ('INFO', 'Info', ''), ('WARNING', 'Warning', ''), ('ERROR', 'Error', ''), ('CRITICAL', 'Critical', '')],
-		update = updateLogLevel,
-		default = 'DEBUG'
-		)
+        logLevel: EnumProperty(
+                name = "Logging level",
+                description = "Select the logging level",
+                items = [('DEBUG', 'Debug', ''), ('INFO', 'Info', ''), ('WARNING', 'Warning', ''), ('ERROR', 'Error', ''), ('CRITICAL', 'Critical', '')],
+                update = updateLogLevel,
+                default = 'DEBUG'
+                )
 
-	################
-	def draw(self, context):
-		layout = self.layout
+        ################
+        def draw(self, context):
+                layout = self.layout
 
-		#SRS
-		box = layout.box()
-		box.label(text='Spatial Reference Systems')
-		row = box.row().split(factor=0.5)
-		row.prop(self, "predefCrs", text='')
-		row.operator("bgis.add_predef_crs", icon='ADD')
-		row.operator("bgis.edit_predef_crs", icon='PREFERENCES')
-		row.operator("bgis.rmv_predef_crs", icon='REMOVE')
-		row.operator("bgis.reset_predef_crs", icon='PLAY_REVERSE')
+                #SRS
+                box = layout.box()
+                box.label(text='Spatial Reference Systems')
+                row = box.row().split(factor=0.5)
+                row.prop(self, "predefCrs", text='')
+                row.operator("bgis.add_predef_crs", icon='ADD')
+                row.operator("bgis.edit_predef_crs", icon='PREFERENCES')
+                row.operator("bgis.rmv_predef_crs", icon='REMOVE')
+                row.operator("bgis.reset_predef_crs", icon='PLAY_REVERSE')
 
-		#Basemaps
-		box = layout.box()
-		box.label(text='Basemaps')
-		box.prop(self, "cacheFolder")
-		row = box.row()
-		row.prop(self, "zoomToMouse")
-		row.prop(self, "lockObj")
-		row.prop(self, "lockOrigin")
-		row.prop(self, "synchOrj")
-		row = box.row()
-		row.prop(self, "resamplAlg")
+                #Basemaps
+                box = layout.box()
+                box.label(text='Basemaps')
+                box.prop(self, "cacheFolder")
+                row = box.row()
+                row.prop(self, "zoomToMouse")
+                row.prop(self, "lockObj")
+                row.prop(self, "lockOrigin")
+                row.prop(self, "synchOrj")
+                row = box.row()
+                row.prop(self, "resamplAlg")
 
-		#IO
-		box = layout.box()
-		box.label(text='Import/Export')
-		row = box.row().split(factor=0.5)
-		split = row.split(factor=0.9, align=True)
-		split.prop(self, "osmTags")
-		split.operator("wm.url_open", icon='INFO').url = "http://wiki.openstreetmap.org/wiki/Map_Features"
-		row.operator("bgis.add_osm_tag", icon='ADD')
-		row.operator("bgis.edit_osm_tag", icon='PREFERENCES')
-		row.operator("bgis.rmv_osm_tag", icon='REMOVE')
-		row.operator("bgis.reset_osm_tags", icon='PLAY_REVERSE')
-		row = box.row()
-		row.prop(self, "mergeDoubles")
-		row.prop(self, "adjust3Dview")
-		row.prop(self, "forceTexturedSolid")
+                #IO
+                box = layout.box()
+                box.label(text='Import/Export')
+                row = box.row().split(factor=0.5)
+                split = row.split(factor=0.9, align=True)
+                split.prop(self, "osmTags")
+                split.operator("wm.url_open", icon='INFO').url = "http://wiki.openstreetmap.org/wiki/Map_Features"
+                row.operator("bgis.add_osm_tag", icon='ADD')
+                row.operator("bgis.edit_osm_tag", icon='PREFERENCES')
+                row.operator("bgis.rmv_osm_tag", icon='REMOVE')
+                row.operator("bgis.reset_osm_tags", icon='PLAY_REVERSE')
+                row = box.row()
+                row.prop(self, "mergeDoubles")
+                row.prop(self, "adjust3Dview")
+                row.prop(self, "forceTexturedSolid")
 
-		#Network
-		box = layout.box()
-		box.label(text='Remote datasource')
-		row = box.row().split(factor=0.5)
-		row.prop(self, "overpassServer")
-		row.operator("bgis.add_overpass_server", icon='ADD')
-		row.operator("bgis.edit_overpass_server", icon='PREFERENCES')
-		row.operator("bgis.rmv_overpass_server", icon='REMOVE')
-		row.operator("bgis.reset_overpass_server", icon='PLAY_REVERSE')
-		row = box.row().split(factor=0.5)
-		row.prop(self, "demServer")
-		row.operator("bgis.add_dem_server", icon='ADD')
-		row.operator("bgis.edit_dem_server", icon='PREFERENCES')
-		row.operator("bgis.rmv_dem_server", icon='REMOVE')
-		row.operator("bgis.reset_dem_server", icon='PLAY_REVERSE')
+                #Network
+                box = layout.box()
+                box.label(text='Remote datasource')
+                row = box.row().split(factor=0.5)
+                row.prop(self, "overpassServer")
+                row.operator("bgis.add_overpass_server", icon='ADD')
+                row.operator("bgis.edit_overpass_server", icon='PREFERENCES')
+                row.operator("bgis.rmv_overpass_server", icon='REMOVE')
+                row.operator("bgis.reset_overpass_server", icon='PLAY_REVERSE')
+                row = box.row().split(factor=0.5)
+                row.prop(self, "demServer")
+                row.operator("bgis.add_dem_server", icon='ADD')
+                row.operator("bgis.edit_dem_server", icon='PREFERENCES')
+                row.operator("bgis.rmv_dem_server", icon='REMOVE')
+                row.operator("bgis.reset_dem_server", icon='PLAY_REVERSE')
 
-		row = box.row()
-		row.label(text="Opentopography Api Key")
-		box.row().prop(self, "opentopography_api_key")
-		#System
-		box = layout.box()
-		box.label(text='System')
-		box.prop(self, "projEngine")
-		box.prop(self, "imgEngine")
-		box.prop(self, "logLevel")
+                row = box.row()
+                row.label(text="Opentopography Api Key")
+                box.row().prop(self, "opentopography_api_key")
+                row = box.row()
+                row.label(text="epsg.io API Key")
+                box.row().prop(self, "epsgioKey")
+                #System
+                box = layout.box()
+                box.label(text='System')
+                box.prop(self, "projEngine")
+                box.prop(self, "imgEngine")
+                box.prop(self, "logLevel")
 
 #######################
 
 class PredefCRS():
 
-	'''
-	Collection of utility methods (callable at class level) to deal with predefined CRS dictionary
-	Can be used by others operators that need to fill their own crs enum
-	'''
+        '''
+        Collection of utility methods (callable at class level) to deal with predefined CRS dictionary
+        Can be used by others operators that need to fill their own crs enum
+        '''
 
-	@staticmethod
-	def getData():
-		'''Load the json string'''
-		prefs = bpy.context.preferences.addons[PKG].preferences
-		return json.loads(prefs.predefCrsJson)
+        @staticmethod
+        def getData():
+                '''Load the json string'''
+                prefs = bpy.context.preferences.addons[PKG].preferences
+                return json.loads(prefs.predefCrsJson)
 
-	@classmethod
-	def getName(cls, key):
-		'''Return the convenient name of a given srid or None if this crs does not exist in the list'''
-		data = cls.getData()
-		try:
-			return [entry[1] for entry in data if entry[0] == key][0]
-		except IndexError:
-			return None
+        @classmethod
+        def getName(cls, key):
+                '''Return the convenient name of a given srid or None if this crs does not exist in the list'''
+                data = cls.getData()
+                try:
+                        return [entry[1] for entry in data if entry[0] == key][0]
+                except IndexError:
+                        return None
 
-	@classmethod
-	def getEnumItems(cls):
-		'''Return a list of predefined crs usable to fill a bpy EnumProperty'''
-		return [tuple(entry) for entry in cls.getData()]
+        @classmethod
+        def getEnumItems(cls):
+                '''Return a list of predefined crs usable to fill a bpy EnumProperty'''
+                return [tuple(entry) for entry in cls.getData()]
 
 
 #################
 # Collection of operators to manage predefined CRS
 
 class BGIS_OT_add_predef_crs(Operator):
-	bl_idname = "bgis.add_predef_crs"
-	bl_description = 'Add predefinate CRS'
-	bl_label = "Add"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.add_predef_crs"
+        bl_description = 'Add predefinate CRS'
+        bl_label = "Add"
+        bl_options = {'INTERNAL'}
 
-	crs: StringProperty(name = "Definition",  description = "Specify EPSG code or Proj4 string definition for this CRS")
-	name: StringProperty(name = "Description", description = "Choose a convenient name for this CRS")
-	desc: StringProperty(name = "Description", description = "Add a description or comment about this CRS")
+        crs: StringProperty(name = "Definition",  description = "Specify EPSG code or Proj4 string definition for this CRS")
+        name: StringProperty(name = "Description", description = "Choose a convenient name for this CRS")
+        desc: StringProperty(name = "Description", description = "Add a description or comment about this CRS")
 
-	def check(self, context):
-		return True
+        def check(self, context):
+                return True
 
-	def search(self, context):
-		if not EPSGIO.ping():
-			self.report({'ERROR'}, "Cannot request epsg.io website")
-		else:
-			results = EPSGIO.search(self.query)
-			self.results = json.dumps(results)
-			if results:
-				self.crs = 'EPSG:' + results[0]['code']
-				self.name = results[0]['name']
+        def search(self, context):
+                if not EPSGIO.ping():
+                        self.report({'ERROR'}, "Cannot request epsg.io website")
+                else:
+                        results = EPSGIO.search(self.query)
+                        self.results = json.dumps(results)
+                        if results:
+                                self.crs = 'EPSG:' + results[0]['code']
+                                self.name = results[0]['name']
 
-	def updEnum(self, context):
-		crsItems = []
-		if self.results != '':
-			for result in json.loads(self.results):
-				srid = 'EPSG:' + result['code']
-				crsItems.append( (result['code'], result['name'], srid) )
-		return crsItems
+        def updEnum(self, context):
+                crsItems = []
+                if self.results != '':
+                        for result in json.loads(self.results):
+                                srid = 'EPSG:' + result['code']
+                                crsItems.append( (result['code'], result['name'], srid) )
+                return crsItems
 
-	def fill(self, context):
-		if self.results != '':
-			crs = [crs for crs in json.loads(self.results) if crs['code'] == self.crsEnum][0]
-			self.crs = 'EPSG:' + crs['code']
-			self.desc = crs['name']
+        def fill(self, context):
+                if self.results != '':
+                        crs = [crs for crs in json.loads(self.results) if crs['code'] == self.crsEnum][0]
+                        self.crs = 'EPSG:' + crs['code']
+                        self.desc = crs['name']
 
-	query: StringProperty(name='Query', description='Hit enter to process the search', update=search)
+        query: StringProperty(name='Query', description='Hit enter to process the search', update=search)
 
-	results: StringProperty()
+        results: StringProperty()
 
-	crsEnum: EnumProperty(name='Results', description='Select the desired CRS', items=updEnum, update=fill)
+        crsEnum: EnumProperty(name='Results', description='Select the desired CRS', items=updEnum, update=fill)
 
-	search: BoolProperty(name='Search', description='Search for coordinate system into EPSG database', default=False)
+        search: BoolProperty(name='Search', description='Search for coordinate system into EPSG database', default=False)
 
-	save: BoolProperty(name='Save to addon preferences',  description='Save Blender user settings after the addition', default=False)
+        save: BoolProperty(name='Save to addon preferences',  description='Save Blender user settings after the addition', default=False)
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)#, width=300)
+        def invoke(self, context, event):
+                return context.window_manager.invoke_props_dialog(self)#, width=300)
 
-	def draw(self, context):
-		layout = self.layout
-		layout.prop(self, 'search')
-		if self.search:
-			layout.prop(self, 'query')
-			layout.prop(self, 'crsEnum')
-			layout.separator()
-		layout.prop(self, 'crs')
-		layout.prop(self, 'name')
-		layout.prop(self, 'desc')
-		#layout.prop(self, 'save') #sincce Blender2.8 prefs are autosaved
+        def draw(self, context):
+                layout = self.layout
+                layout.prop(self, 'search')
+                if self.search:
+                        layout.prop(self, 'query')
+                        layout.prop(self, 'crsEnum')
+                        layout.separator()
+                layout.prop(self, 'crs')
+                layout.prop(self, 'name')
+                layout.prop(self, 'desc')
+                #layout.prop(self, 'save') #sincce Blender2.8 prefs are autosaved
 
-	def execute(self, context):
-		if not SRS.validate(self.crs):
-			self.report({'ERROR'}, 'Invalid CRS')
-		if self.crs.isdigit():
-			self.crs = 'EPSG:' + self.crs
-		#append the new crs def to json string
-		prefs = context.preferences.addons[PKG].preferences
-		data = json.loads(prefs.predefCrsJson)
-		data.append((self.crs, self.name, self.desc))
-		prefs.predefCrsJson = json.dumps(data)
-		#change enum index to new added crs and redraw
-		#prefs.predefCrs = self.crs
-		context.area.tag_redraw()
-		#end
-		if self.save:
-			bpy.ops.wm.save_userpref()
-		return {'FINISHED'}
+        def execute(self, context):
+                if not SRS.validate(self.crs):
+                        self.report({'ERROR'}, 'Invalid CRS')
+                if self.crs.isdigit():
+                        self.crs = 'EPSG:' + self.crs
+                #append the new crs def to json string
+                prefs = context.preferences.addons[PKG].preferences
+                data = json.loads(prefs.predefCrsJson)
+                data.append((self.crs, self.name, self.desc))
+                prefs.predefCrsJson = json.dumps(data)
+                #change enum index to new added crs and redraw
+                #prefs.predefCrs = self.crs
+                context.area.tag_redraw()
+                #end
+                if self.save:
+                        bpy.ops.wm.save_userpref()
+                return {'FINISHED'}
 
 class BGIS_OT_rmv_predef_crs(Operator):
 
-	bl_idname = "bgis.rmv_predef_crs"
-	bl_description = 'Remove predefinate CRS'
-	bl_label = "Remove"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.rmv_predef_crs"
+        bl_description = 'Remove predefinate CRS'
+        bl_label = "Remove"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.predefCrs
-		if key != '':
-			data = json.loads(prefs.predefCrsJson)
-			data = [e for e in data if e[0] != key]
-			prefs.predefCrsJson = json.dumps(data)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.predefCrs
+                if key != '':
+                        data = json.loads(prefs.predefCrsJson)
+                        data = [e for e in data if e[0] != key]
+                        prefs.predefCrsJson = json.dumps(data)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_reset_predef_crs(Operator):
 
-	bl_idname = "bgis.reset_predef_crs"
-	bl_description = 'Reset predefinate CRS'
-	bl_label = "Reset"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.reset_predef_crs"
+        bl_description = 'Reset predefinate CRS'
+        bl_label = "Reset"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		prefs.predefCrsJson = json.dumps(DEFAULT_CRS)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                prefs.predefCrsJson = json.dumps(DEFAULT_CRS)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_edit_predef_crs(Operator):
 
-	bl_idname = "bgis.edit_predef_crs"
-	bl_description = 'Edit predefinate CRS'
-	bl_label = "Edit"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.edit_predef_crs"
+        bl_description = 'Edit predefinate CRS'
+        bl_label = "Edit"
+        bl_options = {'INTERNAL'}
 
-	crs: StringProperty(name = "EPSG code or Proj4 string",  description = "Specify EPSG code or Proj4 string definition for this CRS")
-	name: StringProperty(name = "Description", description = "Choose a convenient name for this CRS")
-	desc: StringProperty(name = "Name", description = "Add a description or comment about this CRS")
+        crs: StringProperty(name = "EPSG code or Proj4 string",  description = "Specify EPSG code or Proj4 string definition for this CRS")
+        name: StringProperty(name = "Description", description = "Choose a convenient name for this CRS")
+        desc: StringProperty(name = "Name", description = "Add a description or comment about this CRS")
 
-	def invoke(self, context, event):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.predefCrs
-		if key == '':
-			return {'CANCELLED'}
-		data = json.loads(prefs.predefCrsJson)
-		entry = [entry for entry in data if entry[0] == key][0]
-		self.crs, self.name, self.desc = entry
-		return context.window_manager.invoke_props_dialog(self)
+        def invoke(self, context, event):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.predefCrs
+                if key == '':
+                        return {'CANCELLED'}
+                data = json.loads(prefs.predefCrsJson)
+                entry = [entry for entry in data if entry[0] == key][0]
+                self.crs, self.name, self.desc = entry
+                return context.window_manager.invoke_props_dialog(self)
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.predefCrs
-		data = json.loads(prefs.predefCrsJson)
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.predefCrs
+                data = json.loads(prefs.predefCrsJson)
 
-		if SRS.validate(self.crs):
-			data = [entry for entry in data if entry[0] != key] #deleting
-			data.append((self.crs, self.name, self.desc))
-			prefs.predefCrsJson = json.dumps(data)
-			context.area.tag_redraw()
-		else:
-			self.report({'ERROR'}, 'Invalid CRS')
+                if SRS.validate(self.crs):
+                        data = [entry for entry in data if entry[0] != key] #deleting
+                        data.append((self.crs, self.name, self.desc))
+                        prefs.predefCrsJson = json.dumps(data)
+                        context.area.tag_redraw()
+                else:
+                        self.report({'ERROR'}, 'Invalid CRS')
 
-		return {'FINISHED'}
+                return {'FINISHED'}
 
 
 #################
 # Collection of operators to manage predefinates OSM Tags
 
 class BGIS_OT_add_osm_tag(Operator):
-	bl_idname = "bgis.add_osm_tag"
-	bl_description = 'Add new predefinate OSM filter tag'
-	bl_label = "Add"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.add_osm_tag"
+        bl_description = 'Add new predefinate OSM filter tag'
+        bl_label = "Add"
+        bl_options = {'INTERNAL'}
 
-	tag: StringProperty(name = "Tag",  description = "Specify the tag (examples : 'building', 'landuse=forest' ...)")
+        tag: StringProperty(name = "Tag",  description = "Specify the tag (examples : 'building', 'landuse=forest' ...)")
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)#, width=300)
+        def invoke(self, context, event):
+                return context.window_manager.invoke_props_dialog(self)#, width=300)
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		tags = json.loads(prefs.osmTagsJson)
-		tags.append(self.tag)
-		prefs.osmTagsJson = json.dumps(tags)
-		prefs.osmTags = self.tag #update current idx
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                tags = json.loads(prefs.osmTagsJson)
+                tags.append(self.tag)
+                prefs.osmTagsJson = json.dumps(tags)
+                prefs.osmTags = self.tag #update current idx
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_rmv_osm_tag(Operator):
 
-	bl_idname = "bgis.rmv_osm_tag"
-	bl_description = 'Remove predefinate OSM filter tag'
-	bl_label = "Remove"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.rmv_osm_tag"
+        bl_description = 'Remove predefinate OSM filter tag'
+        bl_label = "Remove"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		tag = prefs.osmTags
-		if tag != '':
-			tags = json.loads(prefs.osmTagsJson)
-			del tags[tags.index(tag)]
-			prefs.osmTagsJson = json.dumps(tags)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                tag = prefs.osmTags
+                if tag != '':
+                        tags = json.loads(prefs.osmTagsJson)
+                        del tags[tags.index(tag)]
+                        prefs.osmTagsJson = json.dumps(tags)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_reset_osm_tags(Operator):
 
-	bl_idname = "bgis.reset_osm_tags"
-	bl_description = 'Reset predefinate OSM filter tag'
-	bl_label = "Reset"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.reset_osm_tags"
+        bl_description = 'Reset predefinate OSM filter tag'
+        bl_label = "Reset"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		prefs.osmTagsJson = json.dumps(DEFAULT_OSM_TAGS)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                prefs.osmTagsJson = json.dumps(DEFAULT_OSM_TAGS)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_edit_osm_tag(Operator):
 
-	bl_idname = "bgis.edit_osm_tag"
-	bl_description = 'Edit predefinate OSM filter tag'
-	bl_label = "Edit"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.edit_osm_tag"
+        bl_description = 'Edit predefinate OSM filter tag'
+        bl_label = "Edit"
+        bl_options = {'INTERNAL'}
 
-	tag: StringProperty(name = "Tag",  description = "Specify the tag (examples : 'building', 'landuse=forest' ...)")
+        tag: StringProperty(name = "Tag",  description = "Specify the tag (examples : 'building', 'landuse=forest' ...)")
 
-	def invoke(self, context, event):
-		prefs = context.preferences.addons[PKG].preferences
-		self.tag = prefs.osmTags
-		if self.tag == '':
-			return {'CANCELLED'}
-		return context.window_manager.invoke_props_dialog(self)
+        def invoke(self, context, event):
+                prefs = context.preferences.addons[PKG].preferences
+                self.tag = prefs.osmTags
+                if self.tag == '':
+                        return {'CANCELLED'}
+                return context.window_manager.invoke_props_dialog(self)
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		tag = prefs.osmTags
-		tags = json.loads(prefs.osmTagsJson)
-		del tags[tags.index(tag)]
-		tags.append(self.tag)
-		prefs.osmTagsJson = json.dumps(tags)
-		prefs.osmTags = self.tag #update current idx
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                tag = prefs.osmTags
+                tags = json.loads(prefs.osmTagsJson)
+                del tags[tags.index(tag)]
+                tags.append(self.tag)
+                prefs.osmTagsJson = json.dumps(tags)
+                prefs.osmTags = self.tag #update current idx
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 #################
 # Collection of operators to manage DEM server urls
 
 class BGIS_OT_add_dem_server(Operator):
-	bl_idname = "bgis.add_dem_server"
-	bl_description = 'Add new topography web service'
-	bl_label = "Add"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.add_dem_server"
+        bl_description = 'Add new topography web service'
+        bl_label = "Add"
+        bl_options = {'INTERNAL'}
 
-	url: StringProperty(name = "Url template",  description = "Define url template string. Bounding box varaibles are {W}, {E}, {S} and {N}")
-	name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
-	desc: StringProperty(name = "Description", description = "Add a description or comment about this remote datasource")
+        url: StringProperty(name = "Url template",  description = "Define url template string. Bounding box varaibles are {W}, {E}, {S} and {N}")
+        name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
+        desc: StringProperty(name = "Description", description = "Add a description or comment about this remote datasource")
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)#, width=300)
+        def invoke(self, context, event):
+                return context.window_manager.invoke_props_dialog(self)#, width=300)
 
-	def execute(self, context):
-		templates = ['{W}', '{E}', '{S}', '{N}']
-		if all([t in self.url for t in templates]):
-			prefs = context.preferences.addons[PKG].preferences
-			data = json.loads(prefs.demServerJson)
-			data.append( (self.url, self.name, self.desc) )
-			prefs.demServerJson = json.dumps(data)
-			context.area.tag_redraw()
-		else:
-			self.report({'ERROR'}, 'Invalid URL')
-		return {'FINISHED'}
+        def execute(self, context):
+                templates = ['{W}', '{E}', '{S}', '{N}']
+                if all([t in self.url for t in templates]):
+                        prefs = context.preferences.addons[PKG].preferences
+                        data = json.loads(prefs.demServerJson)
+                        data.append( (self.url, self.name, self.desc) )
+                        prefs.demServerJson = json.dumps(data)
+                        context.area.tag_redraw()
+                else:
+                        self.report({'ERROR'}, 'Invalid URL')
+                return {'FINISHED'}
 
 class BGIS_OT_rmv_dem_server(Operator):
 
-	bl_idname = "bgis.rmv_dem_server"
-	bl_description = 'Remove a given topography web service'
-	bl_label = "Remove"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.rmv_dem_server"
+        bl_description = 'Remove a given topography web service'
+        bl_label = "Remove"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.demServer
-		if key != '':
-			data = json.loads(prefs.demServerJson)
-			data = [e for e in data if e[0] != key]
-			prefs.demServerJson = json.dumps(data)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.demServer
+                if key != '':
+                        data = json.loads(prefs.demServerJson)
+                        data = [e for e in data if e[0] != key]
+                        prefs.demServerJson = json.dumps(data)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_reset_dem_server(Operator):
 
-	bl_idname = "bgis.reset_dem_server"
-	bl_description = 'Reset default topographic web server'
-	bl_label = "Reset"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.reset_dem_server"
+        bl_description = 'Reset default topographic web server'
+        bl_label = "Reset"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		prefs.demServerJson = json.dumps(DEFAULT_DEM_SERVER)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                prefs.demServerJson = json.dumps(DEFAULT_DEM_SERVER)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_edit_dem_server(Operator):
 
-	bl_idname = "bgis.edit_dem_server"
-	bl_description = 'Edit a topographic web server'
-	bl_label = "Edit"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.edit_dem_server"
+        bl_description = 'Edit a topographic web server'
+        bl_label = "Edit"
+        bl_options = {'INTERNAL'}
 
-	url: StringProperty(name = "Url template",  description = "Define url template string. Bounding box varaibles are {W}, {E}, {S} and {N}")
-	name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
-	desc: StringProperty(name = "Description", description = "Add a description or comment about this remote datasource")
+        url: StringProperty(name = "Url template",  description = "Define url template string. Bounding box varaibles are {W}, {E}, {S} and {N}")
+        name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
+        desc: StringProperty(name = "Description", description = "Add a description or comment about this remote datasource")
 
-	def invoke(self, context, event):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.demServer
-		if key == '':
-			return {'CANCELLED'}
-		data = json.loads(prefs.demServerJson)
-		entry = [entry for entry in data if entry[0] == key][0]
-		self.url, self.name, self.desc = entry
-		return context.window_manager.invoke_props_dialog(self)
+        def invoke(self, context, event):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.demServer
+                if key == '':
+                        return {'CANCELLED'}
+                data = json.loads(prefs.demServerJson)
+                entry = [entry for entry in data if entry[0] == key][0]
+                self.url, self.name, self.desc = entry
+                return context.window_manager.invoke_props_dialog(self)
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.demServer
-		data = json.loads(prefs.demServerJson)
-		templates = ['{W}', '{E}', '{S}', '{N}']
-		if all([t in self.url for t in templates]):
-			data = [entry for entry in data if entry[0] != key] #deleting
-			data.append((self.url, self.name, self.desc))
-			prefs.demServerJson = json.dumps(data)
-			context.area.tag_redraw()
-		else:
-			self.report({'ERROR'}, 'Invalid URL')
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.demServer
+                data = json.loads(prefs.demServerJson)
+                templates = ['{W}', '{E}', '{S}', '{N}']
+                if all([t in self.url for t in templates]):
+                        data = [entry for entry in data if entry[0] != key] #deleting
+                        data.append((self.url, self.name, self.desc))
+                        prefs.demServerJson = json.dumps(data)
+                        context.area.tag_redraw()
+                else:
+                        self.report({'ERROR'}, 'Invalid URL')
+                return {'FINISHED'}
 
 #################
 
 class EditEnum():
-	'''
-	Helper to deal with an enum property that use a serialized json backend
-	Can be used by others operators to edit and EnumProperty
-	WORK IN PROGRESS
-	'''
+        '''
+        Helper to deal with an enum property that use a serialized json backend
+        Can be used by others operators to edit and EnumProperty
+        WORK IN PROGRESS
+        '''
 
-	def __init__(self, enumName):
-		self.prefs = bpy.context.preferences.addons[PKG].preferences
-		self.enumName = enumName
-		self.jsonName = enumName + 'Json'
+        def __init__(self, enumName):
+                self.prefs = bpy.context.preferences.addons[PKG].preferences
+                self.enumName = enumName
+                self.jsonName = enumName + 'Json'
 
-	def getData(self):
-		'''Load the json string'''
-		data = json.loads(getattr(self.prefs, self.jsonName))
-		return [tuple(entry) for entry in data]
+        def getData(self):
+                '''Load the json string'''
+                data = json.loads(getattr(self.prefs, self.jsonName))
+                return [tuple(entry) for entry in data]
 
-	def append(self, value, label, tooltip, check=lambda x: True):
-		if not check(value):
-			return
-		data = self.getData()
-		data.append((value, label, tooltip))
-		setattr(self.prefs, self.jsonName, json.dumps(data))
+        def append(self, value, label, tooltip, check=lambda x: True):
+                if not check(value):
+                        return
+                data = self.getData()
+                data.append((value, label, tooltip))
+                setattr(self.prefs, self.jsonName, json.dumps(data))
 
-	def remove(self, key):
-		if key != '':
-			data = self.getData()
-			data = [e for e in data if e[0] != key]
-			setattr(self.prefs, self.jsonName, json.dumps(data))
+        def remove(self, key):
+                if key != '':
+                        data = self.getData()
+                        data = [e for e in data if e[0] != key]
+                        setattr(self.prefs, self.jsonName, json.dumps(data))
 
-	def edit(self, key, value, label, tooltip):
-		self.remove(key)
-		self.append(value, label, tooltip)
+        def edit(self, key, value, label, tooltip):
+                self.remove(key)
+                self.append(value, label, tooltip)
 
-	def reset(self):
-		setattr(self.prefs, self.jsonName, json.dumps(DEFAULT_OVERPASS_SERVER))
+        def reset(self):
+                setattr(self.prefs, self.jsonName, json.dumps(DEFAULT_OVERPASS_SERVER))
 
 #################
 # Collection of operators to manage Overpass server urls
 
 class BGIS_OT_add_overpass_server(Operator):
-	bl_idname = "bgis.add_overpass_server"
-	bl_description = 'Add new OSM overpass server url'
-	bl_label = "Add"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.add_overpass_server"
+        bl_description = 'Add new OSM overpass server url'
+        bl_label = "Add"
+        bl_options = {'INTERNAL'}
 
-	url: StringProperty(name = "Url template",  description = "Define the url end point of the overpass server")
-	name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
-	desc: StringProperty(name = "Description", description = "Add a description or comment about this remote server")
+        url: StringProperty(name = "Url template",  description = "Define the url end point of the overpass server")
+        name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
+        desc: StringProperty(name = "Description", description = "Add a description or comment about this remote server")
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)#, width=300)
+        def invoke(self, context, event):
+                return context.window_manager.invoke_props_dialog(self)#, width=300)
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		data = json.loads(prefs.overpassServerJson)
-		data.append( (self.url, self.name, self.desc) )
-		prefs.overpassServerJson = json.dumps(data)
-		#EditEnum('overpassServer').append(self.url, self.name, self.desc, check=lambda url: url.startswith('http'))
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                data = json.loads(prefs.overpassServerJson)
+                data.append( (self.url, self.name, self.desc) )
+                prefs.overpassServerJson = json.dumps(data)
+                #EditEnum('overpassServer').append(self.url, self.name, self.desc, check=lambda url: url.startswith('http'))
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_rmv_overpass_server(Operator):
 
-	bl_idname = "bgis.rmv_overpass_server"
-	bl_description = 'Remove a given overpass server'
-	bl_label = "Remove"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.rmv_overpass_server"
+        bl_description = 'Remove a given overpass server'
+        bl_label = "Remove"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.overpassServer
-		if key != '':
-			data = json.loads(prefs.overpassServerJson)
-			data = [e for e in data if e[0] != key]
-			prefs.overpassServerJson = json.dumps(data)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.overpassServer
+                if key != '':
+                        data = json.loads(prefs.overpassServerJson)
+                        data = [e for e in data if e[0] != key]
+                        prefs.overpassServerJson = json.dumps(data)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_reset_overpass_server(Operator):
 
-	bl_idname = "bgis.reset_overpass_server"
-	bl_description = 'Reset default overpass server'
-	bl_label = "Rest"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.reset_overpass_server"
+        bl_description = 'Reset default overpass server'
+        bl_label = "Rest"
+        bl_options = {'INTERNAL'}
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		prefs.overpassServerJson = json.dumps(DEFAULT_OVERPASS_SERVER)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                prefs.overpassServerJson = json.dumps(DEFAULT_OVERPASS_SERVER)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 class BGIS_OT_edit_overpass_server(Operator):
 
-	bl_idname = "bgis.edit_overpass_server"
-	bl_description = 'Edit an overpass server url'
-	bl_label = "Edit"
-	bl_options = {'INTERNAL'}
+        bl_idname = "bgis.edit_overpass_server"
+        bl_description = 'Edit an overpass server url'
+        bl_label = "Edit"
+        bl_options = {'INTERNAL'}
 
-	url: StringProperty(name = "Url template",  description = "Define the url end point of the overpass server")
-	name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
-	desc: StringProperty(name = "Description", description = "Add a description or comment about this remote server")
+        url: StringProperty(name = "Url template",  description = "Define the url end point of the overpass server")
+        name: StringProperty(name = "Description", description = "Choose a convenient name for this server")
+        desc: StringProperty(name = "Description", description = "Add a description or comment about this remote server")
 
-	def invoke(self, context, event):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.overpassServer
-		if key == '':
-			return {'CANCELLED'}
-		data = json.loads(prefs.overpassServerJson)
-		entry = [entry for entry in data if entry[0] == key][0]
-		self.url, self.name, self.desc = entry
-		return context.window_manager.invoke_props_dialog(self)
+        def invoke(self, context, event):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.overpassServer
+                if key == '':
+                        return {'CANCELLED'}
+                data = json.loads(prefs.overpassServerJson)
+                entry = [entry for entry in data if entry[0] == key][0]
+                self.url, self.name, self.desc = entry
+                return context.window_manager.invoke_props_dialog(self)
 
-	def execute(self, context):
-		prefs = context.preferences.addons[PKG].preferences
-		key = prefs.overpassServer
-		data = json.loads(prefs.overpassServerJson)
-		data = [entry for entry in data if entry[0] != key] #deleting
-		data.append((self.url, self.name, self.desc))
-		prefs.overpassServerJson = json.dumps(data)
-		context.area.tag_redraw()
-		return {'FINISHED'}
+        def execute(self, context):
+                prefs = context.preferences.addons[PKG].preferences
+                key = prefs.overpassServer
+                data = json.loads(prefs.overpassServerJson)
+                data = [entry for entry in data if entry[0] != key] #deleting
+                data.append((self.url, self.name, self.desc))
+                prefs.overpassServerJson = json.dumps(data)
+                context.area.tag_redraw()
+                return {'FINISHED'}
 
 
 classes = [
@@ -841,21 +854,21 @@ BGIS_OT_edit_overpass_server
 ]
 
 def register():
-	for cls in classes:
-		try:
-			bpy.utils.register_class(cls)
-		except ValueError as e:
-			#log.error('Cannot register {}'.format(cls), exc_info=True)
-			log.warning('{} is already registered, now unregister and retry... '.format(cls))
-			bpy.utils.unregister_class(cls)
-			bpy.utils.register_class(cls)
+        for cls in classes:
+                try:
+                        bpy.utils.register_class(cls)
+                except ValueError as e:
+                        #log.error('Cannot register {}'.format(cls), exc_info=True)
+                        log.warning('{} is already registered, now unregister and retry... '.format(cls))
+                        bpy.utils.unregister_class(cls)
+                        bpy.utils.register_class(cls)
 
-	# set default cache folder
-	prefs = bpy.context.preferences.addons[PKG].preferences
-	if prefs.cacheFolder == '':
-		prefs.cacheFolder = APP_DATA
+        # set default cache folder
+        prefs = bpy.context.preferences.addons[PKG].preferences
+        if prefs.cacheFolder == '':
+                prefs.cacheFolder = APP_DATA
 
 
 def unregister():
-	for cls in classes:
-		bpy.utils.unregister_class(cls)
+        for cls in classes:
+                bpy.utils.unregister_class(cls)


### PR DESCRIPTION
## Summary
- add optional `epsg.io` API key setting and preference
- include API key in EPSG.io requests with clear access-denied errors
- fall back to GDAL/pyproj when EPSG.io fails or exceeds limits and warn on shapefile imports

## Testing
- `python -m py_compile core/settings.py core/proj/srv.py core/proj/reproj.py operators/io_import_shp.py prefs.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1f24840bc8321a802876e804b4dbd