### PR TITLE
feat: make EPSG base configurable

### DIFF
--- a/core/proj/reproj.py
+++ b/core/proj/reproj.py
@@ -230,7 +230,7 @@ class Reproj():
                                         raise ReprojError('Too limited built in reprojection capabilities')
                         if self.iproj == 'EPSGIO':
                                 if not  EPSGIO.ping():
-                                        raise ReprojError('Cannot access epsg.io service')
+                                        raise ReprojError('Cannot access {} service'.format(settings.epsgio_url))
 
 
                 if self.iproj == 'GDAL':
@@ -246,7 +246,7 @@ class Reproj():
                         if crs1.isEPSG and crs2.isEPSG:
                                 self.crs1, self.crs2 = crs1.code, crs2.code
                         else:
-                                raise ReprojError('EPSG.io support only EPSG code')
+                                raise ReprojError('{} supports only EPSG code'.format(settings.epsgio_url))
 
                 elif self.iproj == 'BUILTIN':
                         if ((crs1.isWM or crs1.isUTM) and crs2.isWGS84) or (crs1.isWGS84 and (crs2.isWM or crs2.isUTM)):
@@ -314,12 +314,12 @@ class Reproj():
 
                 elif self.iproj == 'EPSGIO':
                         if len(pts) > EPSGIO.MAX_POINTS and self._fallback():
-                                log.warning('Switching from epsg.io to local engine due to feature limit')
+                                log.warning('Switching from %s to local engine due to feature limit', settings.epsgio_url)
                                 return self.pts(pts)
                         try:
                                 return EPSGIO.reprojPts(self.crs1, self.crs2, pts)
                         except Exception as e:
-                                log.warning('epsg.io reprojection failed: %s', e)
+                                log.warning('%s reprojection failed: %s', settings.epsgio_url, e)
                                 if self._fallback():
                                         return self.pts(pts)
                                 if isinstance(e, ReprojError):

--- a/core/proj/srv.py
+++ b/core/proj/srv.py
@@ -33,8 +33,7 @@ DEFAULT_TIMEOUT = 2
 REPROJ_TIMEOUT = 60
 
 ######################################
-# EPSG.io
-# https://github.com/klokantech/epsg.io
+# EPSG web service
 
 
 class EPSGIO():
@@ -50,7 +49,7 @@ class EPSGIO():
 
         @staticmethod
         def ping():
-                url = "http://epsg.io"
+                url = settings.epsgio_url
                 try:
                         EPSGIO._open(url, DEFAULT_TIMEOUT)
                         return True
@@ -66,8 +65,8 @@ class EPSGIO():
 
         @staticmethod
         def reprojPt(epsg1, epsg2, x1, y1):
-
-                url = "http://epsg.io/trans?x={X}&y={Y}&z={Z}&s_srs={CRS1}&t_srs={CRS2}"
+                base = settings.epsgio_url.rstrip('/')
+                url = base + "/trans?x={X}&y={Y}&z={Z}&s_srs={CRS1}&t_srs={CRS2}"
 
                 url = url.replace("{X}", str(x1))
                 url = url.replace("{Y}", str(y1))
@@ -81,7 +80,7 @@ class EPSGIO():
                         response = EPSGIO._open(url, REPROJ_TIMEOUT).read().decode('utf8')
                 except HTTPError as err:
                         if err.code in (401, 403):
-                                raise ReprojError('epsg.io access denied: {} {}'.format(err.code, err.reason))
+                                raise ReprojError('{} access denied: {} {}'.format(settings.epsgio_url, err.code, err.reason))
                         log.error('Http request fails url:{}, code:{}, error:{}'.format(url, err.code, err.reason))
                         raise
                 except URLError as err:
@@ -99,7 +98,8 @@ class EPSGIO():
                         x, y = points[0]
                         return [EPSGIO.reprojPt(epsg1, epsg2, x, y)]
 
-                urlTemplate = "http://epsg.io/trans?data={POINTS}&s_srs={CRS1}&t_srs={CRS2}"
+                base = settings.epsgio_url.rstrip('/')
+                urlTemplate = base + "/trans?data={POINTS}&s_srs={CRS1}&t_srs={CRS2}"
 
                 urlTemplate = urlTemplate.replace("{CRS1}", str(epsg1))
                 urlTemplate = urlTemplate.replace("{CRS2}", str(epsg2))
@@ -127,7 +127,7 @@ class EPSGIO():
                                 response = EPSGIO._open(url, REPROJ_TIMEOUT).read().decode('utf8')
                         except HTTPError as err:
                                 if err.code in (401, 403):
-                                        raise ReprojError('epsg.io access denied: {} {}'.format(err.code, err.reason))
+                                        raise ReprojError('{} access denied: {} {}'.format(settings.epsgio_url, err.code, err.reason))
                                 log.error('Http request fails url:{}, code:{}, error:{}'.format(url, err.code, err.reason))
                                 raise
                         except URLError as err:
@@ -142,7 +142,8 @@ class EPSGIO():
         @staticmethod
         def search(query):
                 query = str(query).replace(' ', '+')
-                url = "http://epsg.io/?q={QUERY}&format=json"
+                base = settings.epsgio_url.rstrip('/')
+                url = base + "/?q={QUERY}&format=json"
                 url = url.replace("{QUERY}", query)
                 log.debug('Search crs : {}'.format(url))
                 response = EPSGIO._open(url, DEFAULT_TIMEOUT).read().decode('utf8')
@@ -152,7 +153,8 @@ class EPSGIO():
 
         @staticmethod
         def getEsriWkt(epsg):
-                url = "http://epsg.io/{CODE}.esriwkt"
+                base = settings.epsgio_url.rstrip('/')
+                url = base + "/{CODE}.esriwkt"
                 url = url.replace("{CODE}", str(epsg))
                 log.debug(url)
                 wkt = EPSGIO._open(url, DEFAULT_TIMEOUT).read().decode('utf8')

--- a/core/settings.json
+++ b/core/settings.json
@@ -1,6 +1,8 @@
 {
-	"proj_engine": "AUTO",
+        "proj_engine": "AUTO",
         "img_engine": "AUTO",
         "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0",
-        "epsgio_key": ""
+        "epsgio_key": "",
+        "epsgio_url": "https://epsg.io",
+        "maptiler_url": "https://api.maptiler.com"
 }

--- a/core/settings.py
+++ b/core/settings.py
@@ -31,8 +31,11 @@ class Settings():
                 self._proj_engine = kwargs['proj_engine']
                 self._img_engine = kwargs['img_engine']
                 self.user_agent = kwargs['user_agent']
-                # Optional API key for epsg.io reprojection service
+                # Optional API key for EPSG reprojection service
                 self.epsgio_key = kwargs.get('epsgio_key', '')
+                # Base URLs for external web services
+                self.epsgio_url = kwargs.get('epsgio_url', 'https://epsg.io')
+                self.maptiler_url = kwargs.get('maptiler_url', 'https://api.maptiler.com')
 
         @property
         def proj_engine(self):
@@ -55,6 +58,18 @@ class Settings():
                         raise IOError
                 else:
                         self._img_engine = engine
+
+        def save(self):
+                data = {
+                        'proj_engine': self.proj_engine,
+                        'img_engine': self.img_engine,
+                        'user_agent': self.user_agent,
+                        'epsgio_key': self.epsgio_key,
+                        'epsgio_url': self.epsgio_url,
+                        'maptiler_url': self.maptiler_url,
+                }
+                with open(cfgFile, 'w') as cfg:
+                        json.dump(data, cfg, indent=8)
 
 
 cfgFile = os.path.join(os.path.dirname(__file__), "settings.json")

--- a/operators/io_import_shp.py
+++ b/operators/io_import_shp.py
@@ -17,6 +17,7 @@ from ..prefs import PredefCRS
 from ..core import BBOX
 from ..core.proj import Reproj, EPSGIO
 from ..core.utils import perf_clock
+from ..core import settings
 
 from .utils import adjust3Dview, getBBOX, DropToGround
 
@@ -444,7 +445,7 @@ class IMPORTGIS_OT_shapefile(Operator):
                                 self.report({'ERROR'}, "Unable to reproject data, check logs for more infos.")
                                 return {'CANCELLED'}
                         if rprj.iproj == 'EPSGIO' and shp.numRecords > EPSGIO.MAX_POINTS:
-                                self.report({'WARNING'}, f"Reprojection through epsg.io will be chunked in batches of {EPSGIO.MAX_POINTS} features and may be slow.")
+                                self.report({'WARNING'}, f"Reprojection through {settings.epsgio_url} will be chunked in batches of {EPSGIO.MAX_POINTS} features and may be slow.")
 
                 #Get bbox
                 bbox = BBOX(shp.bbox)

--- a/prefs.py
+++ b/prefs.py
@@ -115,13 +115,14 @@ class BGIS_PREFS(AddonPreferences):
                 if HAS_PYPROJ:
                         items.append( ('PYPROJ', 'pyProj', 'Force pyProj as reprojection engine') )
                 #if EPSGIO.ping(): #too slow
-                #        items.append( ('EPSGIO', 'epsg.io', '') )
-                items.append( ('EPSGIO', 'epsg.io', 'Force epsg.io as reprojection engine') )
+                #        items.append( ('EPSGIO', settings.epsgio_url, '') )
+                items.append( ('EPSGIO', settings.epsgio_url, f'Force {settings.epsgio_url} as reprojection engine') )
                 items.append( ('BUILTIN', 'Built in', 'Force reprojection through built in Python functions') )
                 return items
 
         def updateProjEngine(self, context):
                 settings.proj_engine = self.projEngine
+                settings.save()
 
         projEngine: EnumProperty(
                 name = "Projection engine",
@@ -132,12 +133,35 @@ class BGIS_PREFS(AddonPreferences):
 
         def updateEpsgioKey(self, context):
                 settings.epsgio_key = self.epsgioKey
+                settings.save()
+
+        def updateEpsgioUrl(self, context):
+                settings.epsgio_url = self.epsgioUrl
+                settings.save()
+
+        def updateMaptilerUrl(self, context):
+                settings.maptiler_url = self.maptilerUrl
+                settings.save()
+
+        epsgioUrl: StringProperty(
+                name = "EPSG base URL",
+                description = "Base URL for EPSG reprojection service",
+                default = settings.epsgio_url,
+                update = updateEpsgioUrl
+                )
 
         epsgioKey: StringProperty(
-                name = "epsg.io API key",
-                description = "Optional API key for epsg.io reprojection service",
-                default = "",
+                name = "EPSG API key",
+                description = f"Optional API key for {settings.epsgio_url} reprojection service",
+                default = settings.epsgio_key,
                 update = updateEpsgioKey
+                )
+
+        maptilerUrl: StringProperty(
+                name = "MapTiler base URL",
+                description = "Base URL for MapTiler web services",
+                default = settings.maptiler_url,
+                update = updateMaptilerUrl
                 )
 
         ################
@@ -155,6 +179,7 @@ class BGIS_PREFS(AddonPreferences):
 
         def updateImgEngine(self, context):
                 settings.img_engine = self.imgEngine
+                settings.save()
 
         imgEngine: EnumProperty(
                 name = "Image processing engine",
@@ -344,8 +369,14 @@ class BGIS_PREFS(AddonPreferences):
                 row.label(text="Opentopography Api Key")
                 box.row().prop(self, "opentopography_api_key")
                 row = box.row()
-                row.label(text="epsg.io API Key")
+                row.label(text="EPSG base URL")
+                box.row().prop(self, "epsgioUrl")
+                row = box.row()
+                row.label(text="EPSG API Key")
                 box.row().prop(self, "epsgioKey")
+                row = box.row()
+                row.label(text="MapTiler base URL")
+                box.row().prop(self, "maptilerUrl")
                 #System
                 box = layout.box()
                 box.label(text='System')
@@ -401,7 +432,7 @@ class BGIS_OT_add_predef_crs(Operator):
 
         def search(self, context):
                 if not EPSGIO.ping():
-                        self.report({'ERROR'}, "Cannot request epsg.io website")
+                        self.report({'ERROR'}, f"Cannot request {settings.epsgio_url} website")
                 else:
                         results = EPSGIO.search(self.query)
                         self.results = json.dumps(results)


### PR DESCRIPTION
## Summary
- configure EPSG/MapTiler base URLs in settings and preferences
- use configured base for EPSGIO service
- reference EPSG service URL from settings across modules

## Testing
- `python -m py_compile core/settings.py core/proj/srv.py core/proj/reproj.py operators/io_import_shp.py prefs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1fdb364648321b7c08dba63cf6b12