### PR TITLE
Fix Blender 4.5 AddonPreferences cache handling and exception hook robustness

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -92,8 +92,13 @@ logger.setLevel(logging.DEBUG)
 logger.info('###### Starting new Blender session : {}'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
 
 def _excepthook(exc_type, exc_value, exc_traceback):
-	if 'BlenderGIS' in exc_traceback.tb_frame.f_code.co_filename:
-		logger.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+	tb = exc_traceback
+	while tb is not None:
+		filename = tb.tb_frame.f_code.co_filename
+		if 'BlenderGIS' in filename:
+			logger.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+			break
+		tb = tb.tb_next
 	sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
 sys.excepthook = _excepthook #warn, this is a global variable, can be overrided by another addon

--- a/operators/view3d_mapviewer.py
+++ b/operators/view3d_mapviewer.py
@@ -74,7 +74,7 @@ class BaseMap(GeoScene):
 
 		#Get cache destination folder in addon preferences
 		prefs = context.preferences.addons[PKG].preferences
-		cacheFolder = prefs.cacheFolder
+		cacheFolder = bpy.path.abspath(prefs.cacheFolder)
 
 		self.synchOrj = prefs.synchOrj
 
@@ -488,7 +488,7 @@ class VIEW3D_OT_map_start(Operator):
 		prefs = context.preferences.addons[PKG].preferences
 
 		#check cache folder
-		folder = prefs.cacheFolder
+		folder = bpy.path.abspath(prefs.cacheFolder)
 		if folder == "" or not os.path.exists(folder):
 			self.report({'ERROR'}, "Please define a valid cache folder path in addon's preferences")
 			return {'CANCELLED'}

--- a/prefs.py
+++ b/prefs.py
@@ -226,23 +226,19 @@ class BGIS_PREFS(AddonPreferences):
         ################
         #Basemaps
 
-        def getCacheFolder(self):
-                return bpy.path.abspath(self.get("cacheFolder", ''))
-
-        def setCacheFolder(self, value):
-                if os.access(value, os.X_OK | os.W_OK):
-                        self["cacheFolder"] = value
-                else:
-                        log.error("The selected cache folder has no write access")
-                        self["cacheFolder"] = "The selected folder has no write access"
+        def updateCacheFolder(self, context):
+                cache_folder = bpy.path.abspath(self.cacheFolder)
+                if os.access(cache_folder, os.X_OK | os.W_OK):
+                        return
+                log.error("The selected cache folder has no write access")
+                self.cacheFolder = APP_DATA
 
         cacheFolder: StringProperty(
                 name = "Cache folder",
                 default = APP_DATA, #Does not works !?
                 description = "Define a folder where to store Geopackage SQlite db",
                 subtype = 'DIR_PATH',
-                get = getCacheFolder,
-                set = setCacheFolder
+                update = updateCacheFolder
                 )
 
         synchOrj: BoolProperty(


### PR DESCRIPTION
### Motivation

- Recent Blender versions (4.5+) no longer tolerate IDProperty-style access patterns in `AddonPreferences`, causing startup errors from the cacheFolder preference and spurious property/IDProperty errors. 
- The addon's custom `sys.excepthook` was fragile (directly assuming a traceback frame shape) and could fail when handling threaded exceptions. 
- Optional dependency checks (GDAL/PyProj/Pillow) are informational and should remain unchanged.

### Description

- Replace IDProperty-style `self[...]` / `self.get(...)` cache handling with a proper `StringProperty` update callback `updateCacheFolder` that validates the resolved path and falls back to `APP_DATA` if invalid (file: `prefs.py`).
- Ensure callers always resolve the preferences path before use by calling `bpy.path.abspath(prefs.cacheFolder)` in the basemap/map viewer code (file: `operators/view3d_mapviewer.py`).
- Harden the global `_excepthook` by iterating traceback frames (`tb.tb_next`) and only logging when a frame filename contains `BlenderGIS`, avoiding direct single-frame assumptions (file: `__init__.py`).

### Testing

- Ran `python -m compileall __init__.py prefs.py operators/view3d_mapviewer.py`, which completed successfully.
- Verified Python files compile without syntax errors after modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc7c238a88321ba039aebcb64f782)